### PR TITLE
Implement dbus support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,6 +255,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
 name = "bindgen"
 version = "0.66.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,6 +379,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-targets 0.48.5",
 ]
@@ -487,6 +494,51 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.53",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.53",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -649,6 +701,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "futures-core"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -730,6 +788,12 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
@@ -782,13 +846,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.3",
+ "serde",
 ]
 
 [[package]]
@@ -801,6 +883,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "js-sys"
@@ -949,6 +1037,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-traits"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1055,6 +1149,12 @@ dependencies = [
  "tracing",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1177,6 +1277,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1200,6 +1306,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.53",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0652c533506ad7a2e353cce269330d6afd8bdfb6d75e0ace5b35aacbd7b9e9"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -1230,6 +1347,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee80b0e361bbf88fd2f6e242ccd19cfda072cb0faa6ae694ecee08199938569a"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.1.0",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6561dc161a9224638a31d876ccdfefbc1df91d3f3a8342eddb35f055d48c7655"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -1378,6 +1525,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "timer"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1413,7 +1591,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
 dependencies = [
- "indexmap",
+ "indexmap 2.1.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -1606,6 +1784,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_regex",
+ "serde_with",
  "signal-hook",
  "timer",
  "wayland-client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,159 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59d2a3357dde987206219e78ecfbbb6e8dad06cbb65292758d3270e6254f7355"
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "258b52a1aa741b9f09783b2d86cf0aeeb617bbf847f6933340a39644227acbdb"
+dependencies = [
+ "event-listener 5.2.0",
+ "event-listener-strategy 0.5.0",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28243a43d821d11341ab73c80bed182dc015c514b951616cf79bd4af39af0c3"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 5.2.0",
+ "event-listener-strategy 0.5.0",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ae5ebefcc48e7452b4987947920dac9450be1110cadf34d1b8c116bdbaf97c"
+dependencies = [
+ "async-lock 3.3.0",
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc19683171f287921f2405677dd2ed2549c3b3bda697a563ebc3a121ace2aba1"
+dependencies = [
+ "async-lock 3.3.0",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcccb0f599cfa2f8ace422d3555572f47424da5648a4382a9dd0310ff8210884"
+dependencies = [
+ "async-lock 3.3.0",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
+dependencies = [
+ "event-listener 2.5.3",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
+dependencies = [
+ "event-listener 4.0.3",
+ "event-listener-strategy 0.4.0",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451e3cf68011bd56771c79db04a9e333095ab6349f7e47592b788e9b98720cc8"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock 3.3.0",
+ "async-signal",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.2.0",
+ "futures-lite",
+ "rustix",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30c5ef0ede93efbf733c1a727f3b6b5a1060bbedd5600183e66f6e4be4af0ec5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.53",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e47d90f65a225c4527103a8d747001fc56e375203592b25ad103e1ca13124c5"
+dependencies = [
+ "async-io",
+ "async-lock 2.8.0",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
+
+[[package]]
+name = "async-trait"
+version = "0.1.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "461abc97219de0eaaf81fe3ef974a540158f3d079c2ab200f891f1a2ef201e85"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.53",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,6 +241,12 @@ checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
 dependencies = [
  "bytemuck",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -112,7 +271,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -126,6 +285,31 @@ name = "bitflags"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
+dependencies = [
+ "async-channel",
+ "async-lock 3.3.0",
+ "async-task",
+ "fastrand",
+ "futures-io",
+ "futures-lite",
+ "piper",
+ "tracing",
+]
 
 [[package]]
 name = "bumpalo"
@@ -172,6 +356,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chrono"
@@ -229,7 +419,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -243,6 +433,15 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "convert_case"
@@ -266,6 +465,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "dlib"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,6 +524,33 @@ name = "downcast-rs"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+
+[[package]]
+name = "endi"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3278c9d5fb675e0a51dabcf4c0d355f692b064171535ba72361be1528a9d8e8d"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c785274071b1b420972453b306eeca06acf4633829db4223b58a2a8c5953bc4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.53",
+]
 
 [[package]]
 name = "env_logger"
@@ -310,6 +582,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b5fb89194fa3cad959b833185b3063ba881dbfc7030680b314250779fb4cc91"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
+dependencies = [
+ "event-listener 4.0.3",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "feedafcaa9b749175d5ac357452a9d41ea2911da598fde46ce1fe02c37751291"
+dependencies = [
+ "event-listener 5.2.0",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
 name = "figment"
 version = "0.10.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,6 +646,80 @@ dependencies = [
  "toml",
  "uncased",
  "version_check",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-lite"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+
+[[package]]
+name = "futures-task"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+
+[[package]]
+name = "futures-util"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -345,6 +745,12 @@ name = "hermit-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "humantime"
@@ -398,9 +804,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.66"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -419,9 +825,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.151"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libloading"
@@ -445,7 +851,7 @@ dependencies = [
  "cookie-factory",
  "libc",
  "libspa-sys",
- "nix",
+ "nix 0.26.4",
  "nom",
  "system-deps",
 ]
@@ -492,6 +898,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,8 +921,21 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.7.1",
  "pin-utils",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset 0.9.0",
 ]
 
 [[package]]
@@ -536,16 +964,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
+
+[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+
+[[package]]
 name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
 
 [[package]]
 name = "pipewire"
@@ -558,7 +1019,7 @@ dependencies = [
  "libc",
  "libspa",
  "libspa-sys",
- "nix",
+ "nix 0.26.4",
  "once_cell",
  "pipewire-sys",
  "thiserror",
@@ -582,10 +1043,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.71"
+name = "polling"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75cb1540fadbd5b8fbccc4dddad2734eba435053f725621c070711a14bb5f4b8"
+checksum = "24f040dee2588b4963afb4e420540439d126f73fdacf4a9c486a96d840bac3c9"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "pin-project-lite",
+ "rustix",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -601,18 +1091,48 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "regex"
-version = "1.10.2"
+name = "rand"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "regex"
+version = "1.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -622,9 +1142,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -645,9 +1165,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.28"
+version = "0.38.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
+checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
@@ -679,7 +1199,7 @@ checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -693,12 +1213,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.53",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -727,10 +1269,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -740,9 +1297,20 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "2.0.43"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee659fb5f3d355364e1f3e5bc10fb82068efbf824a1e9d1c9504244a6469ad53"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -767,6 +1335,18 @@ name = "target-lexicon"
 version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c39fd04924ca3a864207c66fc2cd7d22d7c016007f9ce846cbb9326331930a"
+
+[[package]]
+name = "tempfile"
+version = "3.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "rustix",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "termcolor"
@@ -794,7 +1374,7 @@ checksum = "e7fbe9b594d6568a6a1443250a7e67d80b74e1e96f6d1715e1e21cc1888291d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.53",
 ]
 
 [[package]]
@@ -841,6 +1421,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.53",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "uds_windows"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
+dependencies = [
+ "memoffset 0.9.0",
+ "tempfile",
+ "winapi",
+]
+
+[[package]]
 name = "uncased"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -880,10 +1508,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.89"
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -891,24 +1525,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.89"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.53",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.89"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -916,22 +1550,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.89"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.53",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.89"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "wayland-backend"
@@ -941,7 +1575,7 @@ checksum = "19152ddd73f45f024ed4534d9ca2594e0ef252c1847695255dae47f34df9fbe4"
 dependencies = [
  "cc",
  "downcast-rs",
- "nix",
+ "nix 0.26.4",
  "scoped-tls",
  "smallvec",
  "wayland-sys",
@@ -954,7 +1588,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ca7d52347346f5473bf2f56705f360e8440873052e575e55890c4fa57843ed3"
 dependencies = [
  "bitflags 2.4.1",
- "nix",
+ "nix 0.26.4",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -977,6 +1611,7 @@ dependencies = [
  "wayland-client",
  "wayland-protocols",
  "xdg",
+ "zbus",
 ]
 
 [[package]]
@@ -1199,3 +1834,114 @@ name = "xdg"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
+
+[[package]]
+name = "xdg-home"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21e5a325c3cb8398ad6cf859c1135b25dd29e186679cf2da7581d9679f63b38e"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "zbus"
+version = "4.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9ff46f2a25abd690ed072054733e0bc3157e3d4c45f41bd183dce09c2ff8ab9"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock 3.3.0",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "derivative",
+ "enumflags2",
+ "event-listener 5.2.0",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix 0.28.0",
+ "ordered-stream",
+ "rand",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.52.0",
+ "xdg-home",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e0e3852c93dcdb49c9462afe67a2a468f7bd464150d866e861eaf06208633e0"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 1.0.109",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant",
+]
+
+[[package]]
+name = "zvariant"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c1b3ca6db667bfada0f1ebfc94b2b1759ba25472ee5373d4551bb892616389a"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zvariant_derive",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7a4b236063316163b69039f77ce3117accb41a09567fd24c168e43491e521bc"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bedb16a193cc12451873fee2a1bc6550225acece0e36f333e68326c73c8172"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ xdg = "2.5"
 figment = { version = "0.10", features = ["toml"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_regex = "1.1"
+serde_with = "3.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ chrono = "0.4"
 signal-hook = "0.3"
 wayland-protocols = { version = "0.31", features = ["unstable", "client"] }
 wayland-client = "0.31"
+zbus = "4.1"
 clap = { version = "4.4.12", features = ["derive", "cargo", "string"] }
 regex = "1.10"
 xdg = "2.5"

--- a/README.md
+++ b/README.md
@@ -47,19 +47,17 @@ Usage: wayland-pipewire-idle-inhibit [OPTIONS]
 
 Options:
   -d, --media-minimum-duration <SECONDS>
-          Minimum media duration to inhibit idle
+          Minimum media duration to inhibit idle [default: 5]
   -v, --verbosity <VERBOSITY>
-          Log verbosity [possible values: OFF, ERROR, WARN, INFO, DEBUG, TRACE]
+          Log verbosity [default: WARN] [possible values: OFF, ERROR, WARN, INFO, DEBUG, TRACE]
   -q, --quiet
           Disables logging completely
-  -b, --dbus
+  -i, --idle-inhibitor <IDLE INHIBITOR BACKEND>
+          Sets what idle inhibitor backend to use [default: wayland] [possible values: d-bus, dry-run, wayland]
+  -b, --d-bus
           Enable DBus (org.freedesktop.ScreenSaver) idle inhibitor
-  -B, --no-dbus
-          Disables DBus idle inhibitor
   -w, --wayland
-          Enable Wayland idle inhibitor (Enabled by default)
-  -W, --no-wayland
-          Disables Wayland idle inhibitor
+          Enable Wayland idle inhibitor
   -n, --dry-run
           Only logs (at INFO level) about idle inhibitor state changes
   -c, --config <PATH>
@@ -148,6 +146,7 @@ services.wayland-pipewire-idle-inhibit = {
   settings = {
     verbosity = "INFO";
     media_minimum_duration = 10;
+    idle_inhibitor = "wayland";
     sink_whitelist = [
       { name = "Starship/Matisse HD Audio Controller Analog Stereo"; }
     ];
@@ -217,6 +216,7 @@ set using `--config <PATH>`.
 ```toml
 verbosity = "WARN"
 media_minimum_duration = 5
+idle_inhibitor = "wayland"
 sink_whitelist = [ ]
 node_blacklist = [ ]
 ```

--- a/README.md
+++ b/README.md
@@ -2,22 +2,37 @@
 
 ## Description
 
-Suspends automatic idling of Wayland compositors when media is being played
-through Pipewire.
+Suspends automatic idling when media is being played through Pipewire.
 
-Depends on the Wayland experimental protocol
-[idle-inhibit-unstable-v1](https://wayland.app/protocols/idle-inhibit-unstable-v1)
-and [PipeWire](https://www.pipewire.org/).
+For detecting media being played, it depends on [PipeWire](https://www.pipewire.org/).
 
-Main features:
+For inhibiting idle, it depends, either on:
+
+- Wayland compositors implementing the experimental protocol
+  [idle-inhibit-unstable-v1](https://wayland.app/protocols/idle-inhibit-unstable-v1)
+- Daemons implementing the D-Bus
+  [org.freedesktop.ScreenSaver](https://specifications.freedesktop.org/idle-inhibit-spec/latest/re01.html)
+  service
+
+### Main features
 
 - Inhibit idle when any app plays audio through PipeWire
 - Customisable minimum media duration to inhibit idle (Useful for keeping
   notifications from inhibiting idle)
 - Customisable list of client filters (Useful for ignoring certain programs,
   such as background music)
+- Support for idle inhibiting through Wayland compositors and dbus services
 
 Feedback and contributions are welcome!
+
+## Tested on
+
+- Sway: works fine with the default wayland idle inhibitor
+- Plasma: while in theory it implements the `idle-inhibit-unstable-v1` protocol
+  it seems to be broken. Works fine using the dbus idle inhibitor.
+
+Should work fine with any compositor that implements `idle-inhibit-unstable-v1`
+or any compositor/DE that offers the `org.freedesktop.ScreenSaver` service.
 
 ## Availability
 
@@ -37,6 +52,16 @@ Options:
           Log verbosity [possible values: OFF, ERROR, WARN, INFO, DEBUG, TRACE]
   -q, --quiet
           Disables logging completely
+  -b, --dbus
+          Enable DBus (org.freedesktop.ScreenSaver) idle inhibitor
+  -B, --no-dbus
+          Disables DBus idle inhibitor
+  -w, --wayland
+          Enable Wayland idle inhibitor (Enabled by default)
+  -W, --no-wayland
+          Disables Wayland idle inhibitor
+  -n, --dry-run
+          Only logs (at INFO level) about idle inhibitor state changes
   -c, --config <PATH>
           Path to config file
   -h, --help

--- a/src/idle_inhibitor/dbus/mod.rs
+++ b/src/idle_inhibitor/dbus/mod.rs
@@ -44,12 +44,17 @@ impl<'a> DbusIdleInhibitor<'a> {
         let dbus_connection = Connection::session()?;
         let dbus_proxy = ScreenSaverProxyBlocking::new(&dbus_connection)?;
 
-        debug!(target: "DbusIdleInhibitor::new", "DBus Idle Inhibitor created");
-        Ok(DbusIdleInhibitor {
+        let mut dbus_idle_inhibitor = DbusIdleInhibitor {
             _dbus_connection: dbus_connection,
             dbus_proxy,
             cookie: None,
-        })
+        };
+
+        dbus_idle_inhibitor.inhibit()?;
+        dbus_idle_inhibitor.uninhibit()?;
+
+        debug!(target: "DbusIdleInhibitor::new", "DBus Idle Inhibitor created");
+        Ok(dbus_idle_inhibitor)
     }
 }
 
@@ -83,6 +88,7 @@ impl IdleInhibitor for DbusIdleInhibitor<'_> {
             self.cookie = None;
             info!(target: "DbusIdleInhibitor::uninhibit", "Idle Inhibitor was DISABLED");
         }
+
         Ok(())
     }
 }

--- a/src/idle_inhibitor/dbus/mod.rs
+++ b/src/idle_inhibitor/dbus/mod.rs
@@ -16,7 +16,7 @@
 
 use std::error::Error;
 
-use log::{debug, info};
+use log::{debug, error, info};
 use zbus::{blocking::Connection, proxy};
 
 use super::IdleInhibitor;
@@ -50,6 +50,17 @@ impl<'a> DbusIdleInhibitor<'a> {
             dbus_proxy,
             cookie: None,
         })
+    }
+}
+
+impl Drop for DbusIdleInhibitor<'_> {
+    fn drop(&mut self) {
+        if let Some(cookie) = self.cookie {
+            if let Err(error) = self.dbus_proxy.UnInhibit(cookie) {
+                error!(target: "DbusIdleInhibitor::drop", "{error}");
+            }
+            self.cookie = None;
+        }
     }
 }
 

--- a/src/idle_inhibitor/dbus/mod.rs
+++ b/src/idle_inhibitor/dbus/mod.rs
@@ -1,0 +1,77 @@
+// Copyright (C) 2024  Rafael Carvalho <contact@rafaelrc.com>
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as published by
+// the Free Software Foundation.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::error::Error;
+
+use log::{debug, info};
+use zbus::{blocking::Connection, proxy};
+
+use super::IdleInhibitor;
+
+#[proxy(
+    default_service = "org.freedesktop.ScreenSaver",
+    interface = "org.freedesktop.ScreenSaver",
+    default_path = "/ScreenSaver"
+)]
+trait ScreenSaver {
+    fn Inhibit(&self, application_name: &str, reason_for_inhibit: &str) -> zbus::Result<u32>;
+
+    #[dbus_proxy(no_reply_expected)]
+    fn UnInhibit(&self, cookie: u32) -> zbus::Result<()>;
+}
+
+pub struct DbusIdleInhibitor<'a> {
+    _dbus_connection: Connection,
+    dbus_proxy: ScreenSaverProxyBlocking<'a>,
+    cookie: Option<u32>,
+}
+
+impl<'a> DbusIdleInhibitor<'a> {
+    pub fn new() -> Result<DbusIdleInhibitor<'a>, Box<dyn Error>> {
+        let dbus_connection = Connection::session()?;
+        let dbus_proxy = ScreenSaverProxyBlocking::new(&dbus_connection)?;
+
+        debug!(target: "DbusIdleInhibitor::new", "DBus Idle Inhibitor created");
+        Ok(DbusIdleInhibitor {
+            _dbus_connection: dbus_connection,
+            dbus_proxy,
+            cookie: None,
+        })
+    }
+}
+
+impl IdleInhibitor for DbusIdleInhibitor<'_> {
+    fn inhibit(&mut self) -> Result<(), Box<dyn Error>> {
+        if self.cookie.is_none() {
+            self.cookie = Some(
+                self.dbus_proxy
+                    .Inhibit(env!("CARGO_PKG_NAME"), "Media is being played")?,
+            );
+            info!(target: "DbusIdleInhibitor::inhibit", "Idle Inhibitor was ENABLED");
+        }
+
+        Ok(())
+    }
+
+    fn uninhibit(&mut self) -> Result<(), Box<dyn Error>> {
+        if let Some(cookie) = self.cookie {
+            self.dbus_proxy.UnInhibit(cookie)?;
+            self.cookie = None;
+            info!(target: "DbusIdleInhibitor::uninhibit", "Idle Inhibitor was DISABLED");
+        }
+        Ok(())
+    }
+}

--- a/src/idle_inhibitor/dry/mod.rs
+++ b/src/idle_inhibitor/dry/mod.rs
@@ -16,10 +16,31 @@
 
 use std::error::Error;
 
-pub mod dry;
-pub mod wayland;
+use log::info;
 
-pub trait IdleInhibitor {
-    fn inhibit(&mut self) -> Result<(), Box<dyn Error>>;
-    fn uninhibit(&mut self) -> Result<(), Box<dyn Error>>;
+use super::IdleInhibitor;
+
+#[derive(Default)]
+pub struct DryRunIdleInhibitor {
+    is_idle_inhibited: bool,
+}
+
+impl IdleInhibitor for DryRunIdleInhibitor {
+    fn inhibit(&mut self) -> Result<(), Box<dyn Error>> {
+        if !self.is_idle_inhibited {
+            self.is_idle_inhibited = true;
+            info!(target: "DryRunIdleInhibitor::inhibit", "Idle Inhibitor was ENABLED");
+        }
+
+        Ok(())
+    }
+
+    fn uninhibit(&mut self) -> Result<(), Box<dyn Error>> {
+        if self.is_idle_inhibited {
+            self.is_idle_inhibited = false;
+            info!(target: "DryRunIdleInhibitor::inhibit", "Idle Inhibitor was DISABLED");
+        }
+
+        Ok(())
+    }
 }

--- a/src/idle_inhibitor/mod.rs
+++ b/src/idle_inhibitor/mod.rs
@@ -1,0 +1,24 @@
+// Copyright (C) 2024  Rafael Carvalho <contact@rafaelrc.com>
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as published by
+// the Free Software Foundation.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::error::Error;
+
+pub mod wayland;
+
+pub trait IdleInhibitor {
+    fn inhibit(&mut self) -> Result<(), Box<dyn Error>>;
+    fn uninhibit(&mut self) -> Result<(), Box<dyn Error>>;
+}

--- a/src/idle_inhibitor/mod.rs
+++ b/src/idle_inhibitor/mod.rs
@@ -16,6 +16,7 @@
 
 use std::error::Error;
 
+pub mod dbus;
 pub mod dry;
 pub mod wayland;
 

--- a/src/idle_inhibitor/wayland/mod.rs
+++ b/src/idle_inhibitor/wayland/mod.rs
@@ -34,6 +34,8 @@ use wayland_protocols::wp::idle_inhibit::zv1::client::{
 
 use log::{debug, info, warn};
 
+use super::IdleInhibitor;
+
 /// Wrapper to the Wayland objects and the idle inhibitor protocol
 pub struct WaylandIdleInhibitor {
     _connection: Connection,
@@ -42,6 +44,16 @@ pub struct WaylandIdleInhibitor {
     qhandle: QueueHandle<AppData>,
     _registry: WlRegistry,
     data: AppData,
+}
+
+impl IdleInhibitor for WaylandIdleInhibitor {
+    fn inhibit(&mut self) -> Result<(), Box<dyn Error>> {
+        self.set_inhibit_idle(true)
+    }
+
+    fn uninhibit(&mut self) -> Result<(), Box<dyn Error>> {
+        self.set_inhibit_idle(false)
+    }
 }
 
 impl WaylandIdleInhibitor {

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,10 +81,13 @@ fn main() {
     );
 
     let mut idle_inhibitors: Vec<Box<dyn IdleInhibitor>> = Vec::new();
-    match WaylandIdleInhibitor::new() {
-        Ok(wayland_idle_inhibitor) => idle_inhibitors.push(Box::new(wayland_idle_inhibitor)),
-        Err(error) => panic!("{}", error),
-    };
+
+    if settings.is_wayland_enabled() {
+        match WaylandIdleInhibitor::new() {
+            Ok(wayland_idle_inhibitor) => idle_inhibitors.push(Box::new(wayland_idle_inhibitor)),
+            Err(error) => panic!("{}", error),
+        };
+    }
 
     let mut inhibit_idle_state_manager: InhibitIdleState<Msg> =
         InhibitIdleState::new(settings.get_media_minimum_duration(), event_queue_sender);

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ mod pipewire_connection;
 use pipewire_connection::{PWEvent, PWMsg, PWThread};
 
 mod idle_inhibitor;
-use idle_inhibitor::{wayland::WaylandIdleInhibitor, IdleInhibitor};
+use idle_inhibitor::{dry::DryRunIdleInhibitor, wayland::WaylandIdleInhibitor, IdleInhibitor};
 
 mod settings;
 use settings::Settings;
@@ -87,6 +87,10 @@ fn main() {
             Ok(wayland_idle_inhibitor) => idle_inhibitors.push(Box::new(wayland_idle_inhibitor)),
             Err(error) => panic!("{}", error),
         };
+    }
+
+    if settings.is_dry_run() {
+        idle_inhibitors.push(Box::<DryRunIdleInhibitor>::default());
     }
 
     let mut inhibit_idle_state_manager: InhibitIdleState<Msg> =

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,9 @@ mod pipewire_connection;
 use pipewire_connection::{PWEvent, PWMsg, PWThread};
 
 mod idle_inhibitor;
-use idle_inhibitor::{dry::DryRunIdleInhibitor, wayland::WaylandIdleInhibitor, IdleInhibitor};
+use idle_inhibitor::{
+    dbus::DbusIdleInhibitor, dry::DryRunIdleInhibitor, wayland::WaylandIdleInhibitor, IdleInhibitor,
+};
 
 mod settings;
 use settings::Settings;
@@ -81,6 +83,13 @@ fn main() {
     );
 
     let mut idle_inhibitors: Vec<Box<dyn IdleInhibitor>> = Vec::new();
+
+    if settings.is_dbus_enabled() {
+        match DbusIdleInhibitor::new() {
+            Ok(dbus_idle_inhibitor) => idle_inhibitors.push(Box::new(dbus_idle_inhibitor)),
+            Err(error) => panic!("{}", error),
+        }
+    }
 
     if settings.is_wayland_enabled() {
         match WaylandIdleInhibitor::new() {

--- a/src/pipewire_connection/graph/filter.rs
+++ b/src/pipewire_connection/graph/filter.rs
@@ -72,8 +72,7 @@ fn matches_property(filter: &Option<Regex>, property: Option<&str>) -> bool {
 /// [super::NodeData]s.
 #[derive(Serialize, Deserialize, Clone)]
 pub struct SinkFilter {
-    #[serde(with = "serde_regex")]
-    #[serde(default)]
+    #[serde(default, with = "serde_regex")]
     name: Option<Regex>,
 }
 
@@ -86,24 +85,19 @@ impl Filter<NodeData> for SinkFilter {
 /// Represents a [Filter] over a generic Node, and thus filters over [super::NodeData]s.
 #[derive(Serialize, Deserialize, Clone)]
 pub struct NodeFilter {
-    #[serde(with = "serde_regex")]
-    #[serde(default)]
+    #[serde(default, with = "serde_regex")]
     name: Option<Regex>,
 
-    #[serde(with = "serde_regex")]
-    #[serde(default)]
+    #[serde(default, with = "serde_regex")]
     app_name: Option<Regex>,
 
-    #[serde(with = "serde_regex")]
-    #[serde(default)]
+    #[serde(default, with = "serde_regex")]
     media_class: Option<Regex>,
 
-    #[serde(with = "serde_regex")]
-    #[serde(default)]
+    #[serde(default, with = "serde_regex")]
     media_role: Option<Regex>,
 
-    #[serde(with = "serde_regex")]
-    #[serde(default)]
+    #[serde(default, with = "serde_regex")]
     media_software: Option<Regex>,
 }
 

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -21,12 +21,14 @@ use std::fmt::Display;
 use clap::{builder::PossibleValue, Parser, ValueEnum};
 use log::LevelFilter;
 use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, NoneAsEmptyString};
 
 use super::IdleInhibitor;
 
 /// Struct used to derive, parse and serialise CLI args. Some of the fields will not be used by the
 /// application and are only relevant in the context of CLI arguments, and thus have their
 /// serialisation skipped.
+#[serde_as]
 #[derive(Parser, Debug, Serialize, Deserialize)]
 #[command(author, version, about)]
 pub struct Args {
@@ -69,6 +71,7 @@ pub struct Args {
         help = format!("Sets what idle inhibitor backend to use [default: {}]", super::default_idle_inhibitor())
     )]
     #[serde(skip_serializing_if = "::std::option::Option::is_none")]
+    #[serde_as(as = "NoneAsEmptyString")]
     idle_inhibitor: Option<IdleInhibitor>,
 
     #[arg(

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -57,8 +57,7 @@ pub struct Args {
         conflicts_with = "verbosity",
         help = "Disables logging completely"
     )]
-    #[serde(skip_serializing)]
-    #[serde(default)]
+    #[serde(default, skip_serializing)]
     quiet: bool,
 
     #[arg(
@@ -82,8 +81,7 @@ pub struct Args {
         conflicts_with = "idle_inhibitor",
         help = "Enable DBus (org.freedesktop.ScreenSaver) idle inhibitor"
     )]
-    #[serde(skip_serializing)]
-    #[serde(default)]
+    #[serde(default, skip_serializing)]
     dbus: bool,
 
     #[arg(
@@ -94,8 +92,7 @@ pub struct Args {
         conflicts_with = "idle_inhibitor",
         help = "Enable Wayland idle inhibitor"
     )]
-    #[serde(skip_serializing)]
-    #[serde(default)]
+    #[serde(default, skip_serializing)]
     wayland: bool,
 
     #[arg(
@@ -106,12 +103,11 @@ pub struct Args {
         conflicts_with = "idle_inhibitor",
         help = "Only logs (at INFO level) about idle inhibitor state changes"
     )]
-    #[serde(skip_serializing)]
-    #[serde(default)]
+    #[serde(default, skip_serializing)]
     dry_run: bool,
 
     #[arg(short, long, value_name = "PATH", help = "Path to config file")]
-    #[serde(skip_serializing)]
+    #[serde(default, skip_serializing)]
     pub config: Option<String>,
 }
 

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -58,6 +58,28 @@ pub struct Args {
     quiet: bool,
 
     #[arg(
+        short = 'b',
+        long = "dbus",
+        default_value = false.to_string(),
+        default_value_if("no_dbus", true.to_string(), false.to_string()),
+        default_value_if("dry_run", true.to_string(), false.to_string()),
+        conflicts_with = "no_dbus",
+        conflicts_with = "dry_run",
+        help="Enable DBus (org.freedesktop.ScreenSaver) idle inhibitor"
+    )]
+    dbus: bool,
+
+    #[arg(
+        short = 'B',
+        long = "no-dbus",
+        conflicts_with = "dbus",
+        help = "Disables DBus idle inhibitor"
+    )]
+    #[serde(skip_serializing)]
+    #[serde(default)]
+    no_dbus: bool,
+
+    #[arg(
         short = 'w',
         long = "wayland",
         default_value = true.to_string(),

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -35,7 +35,7 @@ pub struct Args {
         long,
         value_name = "SECONDS",
         allow_negative_numbers = false,
-        help = "Minimum media duration to inhibit idle"
+        help = format!("Minimum media duration to inhibit idle [default: {}]", super::defalt_media_minimum_duration())
     )]
     #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     media_minimum_duration: Option<i64>,
@@ -44,7 +44,7 @@ pub struct Args {
         short,
         long,
         default_value_if("quiet", true.to_string(), LogLevel(LevelFilter::Off).to_string()),
-        help="Log verbosity"
+        help = format!("Log verbosity [default: {}]", super::default_verbosity())
     )]
     #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     verbosity: Option<LogLevel>,

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -56,6 +56,25 @@ pub struct Args {
     #[serde(default)]
     quiet: bool,
 
+    #[arg(
+        short = 'w',
+        long = "wayland",
+        default_value = true.to_string(),
+        default_value_if("no_wayland", true.to_string(), false.to_string()),
+        help="Enable Wayland idle inhibitor",
+        conflicts_with = "no_wayland")]
+    wayland: bool,
+
+    #[arg(
+        short = 'W',
+        long = "no-wayland",
+        help = "Disables Wayland idle inhibitor",
+        conflicts_with = "wayland"
+    )]
+    #[serde(skip_serializing)]
+    #[serde(default)]
+    no_wayland: bool,
+
     #[arg(short, long, value_name = "PATH", help = "Path to config file")]
     #[serde(skip_serializing)]
     pub config: Option<String>,

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -42,7 +42,8 @@ pub struct Args {
         short,
         long,
         default_value_if("quiet", true.to_string(), LogLevel(LevelFilter::Off).to_string()),
-        help="Log verbosity")]
+        help="Log verbosity"
+    )]
     #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     verbosity: Option<LogLevel>,
 
@@ -62,16 +63,17 @@ pub struct Args {
         default_value = true.to_string(),
         default_value_if("no_wayland", true.to_string(), false.to_string()),
         default_value_if("dry_run", true.to_string(), false.to_string()),
-        help="Enable Wayland idle inhibitor",
         conflicts_with = "no_wayland",
-        conflicts_with = "dry_run")]
+        conflicts_with = "dry_run",
+        help="Enable Wayland idle inhibitor (Enabled by default)"
+    )]
     wayland: bool,
 
     #[arg(
         short = 'W',
         long = "no-wayland",
-        help = "Disables Wayland idle inhibitor",
-        conflicts_with = "wayland"
+        conflicts_with = "wayland",
+        help = "Disables Wayland idle inhibitor"
     )]
     #[serde(skip_serializing)]
     #[serde(default)]
@@ -81,8 +83,8 @@ pub struct Args {
         short = 'n',
         long = "dry-run",
         default_value = false.to_string(),
-        help = "Only logs about idle inhibitor state changes",
-        conflicts_with = "wayland"
+        conflicts_with = "wayland",
+        help = "Only logs (at INFO level) about idle inhibitor state changes"
     )]
     dry_run: bool,
 

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -61,8 +61,10 @@ pub struct Args {
         long = "wayland",
         default_value = true.to_string(),
         default_value_if("no_wayland", true.to_string(), false.to_string()),
+        default_value_if("dry_run", true.to_string(), false.to_string()),
         help="Enable Wayland idle inhibitor",
-        conflicts_with = "no_wayland")]
+        conflicts_with = "no_wayland",
+        conflicts_with = "dry_run")]
     wayland: bool,
 
     #[arg(
@@ -74,6 +76,15 @@ pub struct Args {
     #[serde(skip_serializing)]
     #[serde(default)]
     no_wayland: bool,
+
+    #[arg(
+        short = 'n',
+        long = "dry-run",
+        default_value = false.to_string(),
+        help = "Only logs about idle inhibitor state changes",
+        conflicts_with = "wayland"
+    )]
+    dry_run: bool,
 
     #[arg(short, long, value_name = "PATH", help = "Path to config file")]
     #[serde(skip_serializing)]

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -142,19 +142,24 @@ impl FromStr for IdleInhibitor {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "d-bus" => Ok(Self::DBus),
+            "dbus" => Ok(Self::DBus),
             "dry-run" => Ok(Self::DryRun),
             "wayland" => Ok(Self::Wayland),
-            _ => Err(ParseIdleInhibitorError),
+            _ => Err(ParseIdleInhibitorError(s.into())),
         }
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ParseIdleInhibitorError;
+pub struct ParseIdleInhibitorError(String);
 
 impl Display for ParseIdleInhibitorError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("Provided value is not a valid IdleInhibitor variant")
+        format!(
+            "Provided value '{}' is not a valid IdleInhibitor variant",
+            self.0
+        )
+        .fmt(f)
     }
 }
 

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -103,12 +103,12 @@ impl Settings {
 }
 
 /// Default media minimum duration, set to 5 seconds
-fn defalt_media_minimum_duration() -> i64 {
+const fn defalt_media_minimum_duration() -> i64 {
     5
 }
 
 /// Default log verbosity, set to [LevelFilter::Warn]
-fn default_verbosity() -> LevelFilter {
+const fn default_verbosity() -> LevelFilter {
     LevelFilter::Warn
 }
 

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -46,6 +46,9 @@ pub struct Settings {
 
     #[serde(default)]
     node_blacklist: Vec<NodeFilter>,
+
+    #[serde(default = "default_wayland")]
+    wayland: bool,
 }
 
 impl Settings {
@@ -89,6 +92,10 @@ impl Settings {
     pub fn get_node_blacklist(&self) -> &Vec<NodeFilter> {
         &self.node_blacklist
     }
+
+    pub fn is_wayland_enabled(&self) -> bool {
+        self.wayland
+    }
 }
 
 /// Default media minimum duration, set to 5 seconds
@@ -99,4 +106,8 @@ fn defalt_media_minimum_duration() -> i64 {
 /// Default log verbosity, set to [LevelFilter::Warn]
 fn default_verbosity() -> LevelFilter {
     LevelFilter::Warn
+}
+
+fn default_wayland() -> bool {
+    true
 }

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -46,6 +46,9 @@ pub struct Settings {
     #[serde(default)]
     node_blacklist: Vec<NodeFilter>,
 
+    #[serde(default = "default_dbus")]
+    dbus: bool,
+
     #[serde(default = "default_wayland")]
     wayland: bool,
 
@@ -100,6 +103,10 @@ impl Settings {
         &self.node_blacklist
     }
 
+    pub fn is_dbus_enabled(&self) -> bool {
+        self.dbus
+    }
+
     pub fn is_wayland_enabled(&self) -> bool {
         self.wayland
     }
@@ -117,6 +124,10 @@ fn defalt_media_minimum_duration() -> i64 {
 /// Default log verbosity, set to [LevelFilter::Warn]
 fn default_verbosity() -> LevelFilter {
     LevelFilter::Warn
+}
+
+fn default_dbus() -> bool {
+    false
 }
 
 fn default_wayland() -> bool {

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -49,6 +49,9 @@ pub struct Settings {
 
     #[serde(default = "default_wayland")]
     wayland: bool,
+
+    #[serde(default = "default_dry_run")]
+    dry_run: bool,
 }
 
 impl Settings {
@@ -96,6 +99,10 @@ impl Settings {
     pub fn is_wayland_enabled(&self) -> bool {
         self.wayland
     }
+
+    pub fn is_dry_run(&self) -> bool {
+        self.dry_run
+    }
 }
 
 /// Default media minimum duration, set to 5 seconds
@@ -110,4 +117,8 @@ fn default_verbosity() -> LevelFilter {
 
 fn default_wayland() -> bool {
     true
+}
+
+fn default_dry_run() -> bool {
+    false
 }


### PR DESCRIPTION
Add support for inhibiting idle trough the `org.freedesktop.ScreenSaver` dbus service. Also reorganises code to let user decide what to use as the idle inhibitor backend.

Closes #2 .