### PR TITLE
Refactor Flake to support non-HM module

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,15 +143,21 @@ wayland-pipewire-idle-inhibit = {
 
 From this point you have many options:
 
-#### Using the Home Manager module (recommended)
+#### Using the module (recommended)
 
-Add the following to your home-manager imports:
+Add the following to your imports:
+
+```nix
+inputs.wayland-pipewire-idle-inhibit.nixosModules.default
+```
+
+Or alternatively, to your home-manager imports:
 
 ```nix
 inputs.wayland-pipewire-idle-inhibit.homeModules.default
 ```
 
-And then you may use the option to set it up, for example:
+And then you may use the options to set it up, for example:
 
 ```nix
 services.wayland-pipewire-idle-inhibit = {

--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,7 @@
 , wayland-protocols
 }:
 let cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
-in rustPlatform.buildRustPackage rec {
+in rustPlatform.buildRustPackage {
   inherit (cargoToml.package) version;
   pname = cargoToml.package.name;
   cargoLock.lockFile = ./Cargo.lock;

--- a/flake.nix
+++ b/flake.nix
@@ -17,8 +17,12 @@
         inputs.flake-parts.flakeModules.easyOverlay
       ];
       flake = {
+        nixosModules = rec {
+          wayland-pipewire-idle-inhibit = import ./modules/nixos.nix;
+          default = wayland-pipewire-idle-inhibit;
+        };
         homeModules = rec {
-          wayland-pipewire-idle-inhibit = import ./module.nix;
+          wayland-pipewire-idle-inhibit = import ./modules/home-manager.nix;
           default = wayland-pipewire-idle-inhibit;
         };
       };

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -1,9 +1,7 @@
-{ config, lib, pkgs, ... }:
+{ lib, pkgs, ... }:
 with lib;
 let
-  cfg = config.services.wayland-pipewire-idle-inhibit;
   tomlFormat = pkgs.formats.toml { };
-  configFile = tomlFormat.generate "wayland-pipewire-idle-inhibit.toml" cfg.settings;
 in
 {
   options.services.wayland-pipewire-idle-inhibit = {
@@ -11,7 +9,7 @@ in
 
     package = mkOption {
       type = types.package;
-      default = pkgs.callPackage ./default.nix { };
+      default = pkgs.callPackage ../default.nix { };
       description = ''
         The wayland-pipewire-idle-inhibit package to use.
       '';
@@ -41,23 +39,6 @@ in
       description = ''
         systemd target to bind to.
       '';
-    };
-  };
-
-  config = mkIf cfg.enable {
-    systemd.user.services.wayland-pipewire-idle-inhibit = {
-      Unit = {
-        Description = "Inhibit Wayland idling when media is played through pipewire";
-        Documentation = "https://github.com/rafaelrc7/wayland-pipewire-idle-inhibit";
-      };
-
-      Install.WantedBy = [ cfg.systemdTarget ];
-
-      Service = {
-        ExecStart = "${cfg.package}/bin/wayland-pipewire-idle-inhibit --config ${configFile}";
-        Restart = "always";
-        RestartSec = 10;
-      };
     };
   };
 }

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -1,0 +1,27 @@
+{ config, lib, pkgs, ... }:
+with lib;
+let
+  cfg = config.services.wayland-pipewire-idle-inhibit;
+  tomlFormat = pkgs.formats.toml { };
+  configFile = tomlFormat.generate "wayland-pipewire-idle-inhibit.toml" cfg.settings;
+in
+{
+  imports = [ ./common.nix ];
+
+  config = mkIf cfg.enable {
+    systemd.user.services.wayland-pipewire-idle-inhibit = {
+      Unit = {
+        Description = "Inhibit Wayland idling when media is played through pipewire";
+        Documentation = "https://github.com/rafaelrc7/wayland-pipewire-idle-inhibit";
+      };
+
+      Install.WantedBy = [ cfg.systemdTarget ];
+
+      Service = {
+        ExecStart = "${cfg.package}/bin/wayland-pipewire-idle-inhibit --config ${configFile}";
+        Restart = "always";
+        RestartSec = 10;
+      };
+    };
+  };
+}

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -1,0 +1,27 @@
+{ config, lib, pkgs, ... }:
+with lib;
+let
+  cfg = config.services.wayland-pipewire-idle-inhibit;
+  tomlFormat = pkgs.formats.toml { };
+  configFile = tomlFormat.generate "wayland-pipewire-idle-inhibit.toml" cfg.settings;
+in
+{
+  imports = [ ./common.nix ];
+
+  config = mkIf cfg.enable {
+    systemd.user.services.wayland-pipewire-idle-inhibit = {
+      unitConfig = {
+        Description = "Inhibit Wayland idling when media is played through pipewire";
+        Documentation = "https://github.com/rafaelrc7/wayland-pipewire-idle-inhibit";
+      };
+
+      wantedBy = [ cfg.systemdTarget ];
+
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/wayland-pipewire-idle-inhibit --config ${configFile}";
+        Restart = "always";
+        RestartSec = 10;
+      };
+    };
+  };
+}


### PR DESCRIPTION
For some reason, the systemd options are named differently between nixpkgs and home-manager...

I'm not good with Nix, so the style may not be the best.

Tested the nixos module with KDE Wayland.
```nix
services.wayland-pipewire-idle-inhibit = {
  enable = true;
  settings = {
    idle_inhibitor = "d-bus";
  };
};
```