### PR TITLE
Refactor wayland and fix output related problems

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1033,6 +1033,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1889,6 +1901,7 @@ dependencies = [
  "clap",
  "figment",
  "log",
+ "nix 0.30.1",
  "pipewire",
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ chrono = "0.4"
 clap = { version = "4.5", features = ["derive", "cargo", "string"] }
 figment = { version = "0.10", features = ["toml"] }
 log = { version = "0.4", features = ["serde"] }
+nix = { version = "0.30", features = ["event", "mqueue"] }
 pipewire = "0.8"
 regex = "1.10"
 serde_regex = "1.1"

--- a/src/idle_inhibitor/mod.rs
+++ b/src/idle_inhibitor/mod.rs
@@ -16,8 +16,6 @@
 
 use std::error::Error;
 
-use wayland_client::backend::ReadEventsGuard;
-
 pub mod dbus;
 pub mod dry;
 pub mod wayland;
@@ -28,18 +26,4 @@ pub trait IdleInhibitor {
 
     /// Uninhibit Idle, does nothing if idle is not inhibited
     fn uninhibit(&mut self) -> Result<(), Box<dyn Error>>;
-
-    /// Get a read lock of the event queue, flushing necessary events.
-    ///
-    /// Only relevant for implementations dependent on Wayland
-    fn wayland_queue_read_guard(&mut self) -> Result<Option<ReadEventsGuard>, Box<dyn Error>> {
-        Ok(None)
-    }
-
-    /// Dispatch and process new events in queue.
-    ///
-    /// Only relevant for implementations dependent on Wayland
-    fn wayland_dispatch_pending(&mut self) -> Result<(), Box<dyn Error>> {
-        Ok(())
-    }
 }

--- a/src/idle_inhibitor/mod.rs
+++ b/src/idle_inhibitor/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2024  Rafael Carvalho <contact@rafaelrc.com>
+// Copyright (C) 2024-2025  Rafael Carvalho <contact@rafaelrc.com>
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 3 as published by
@@ -11,16 +11,35 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-//
+
 // SPDX-License-Identifier: GPL-3.0-only
 
 use std::error::Error;
+
+use wayland_client::backend::ReadEventsGuard;
 
 pub mod dbus;
 pub mod dry;
 pub mod wayland;
 
 pub trait IdleInhibitor {
+    /// Inhibit Idle, does nothing if idle is already inhibited
     fn inhibit(&mut self) -> Result<(), Box<dyn Error>>;
+
+    /// Uninhibit Idle, does nothing if idle is not inhibited
     fn uninhibit(&mut self) -> Result<(), Box<dyn Error>>;
+
+    /// Get a read lock of the event queue, flushing necessary events.
+    ///
+    /// Only relevant for implementations dependent on Wayland
+    fn wayland_queue_read_guard(&mut self) -> Result<Option<ReadEventsGuard>, Box<dyn Error>> {
+        Ok(None)
+    }
+
+    /// Dispatch and process new events in queue.
+    ///
+    /// Only relevant for implementations dependent on Wayland
+    fn wayland_dispatch_pending(&mut self) -> Result<(), Box<dyn Error>> {
+        Ok(())
+    }
 }

--- a/src/idle_inhibitor/wayland/mod.rs
+++ b/src/idle_inhibitor/wayland/mod.rs
@@ -442,14 +442,13 @@ impl Dispatch<WlBuffer, ()> for WaylandIdleInhibitor {
     }
 }
 
-// These interfaces have no events.
-delegate_noop!(WaylandIdleInhibitor: WlCompositor);
-delegate_noop!(WaylandIdleInhibitor: ZwpIdleInhibitManagerV1);
-delegate_noop!(WaylandIdleInhibitor: ZwpIdleInhibitorV1);
-delegate_noop!(WaylandIdleInhibitor: WlShmPool);
-delegate_noop!(WaylandIdleInhibitor: ZwlrLayerShellV1);
-
 // Ignore events from these object types.
-delegate_noop!(WaylandIdleInhibitor: ignore WlSurface);
-delegate_noop!(WaylandIdleInhibitor: ignore WlShm);
 delegate_noop!(WaylandIdleInhibitor: ignore WlOutput);
+delegate_noop!(WaylandIdleInhibitor: ignore WlShm);
+delegate_noop!(WaylandIdleInhibitor: ignore WlSurface);
+
+delegate_noop!(WaylandIdleInhibitor: ignore WlCompositor);
+delegate_noop!(WaylandIdleInhibitor: ignore WlShmPool);
+delegate_noop!(WaylandIdleInhibitor: ignore ZwlrLayerShellV1);
+delegate_noop!(WaylandIdleInhibitor: ignore ZwpIdleInhibitManagerV1);
+delegate_noop!(WaylandIdleInhibitor: ignore ZwpIdleInhibitorV1);

--- a/src/idle_inhibitor/wayland/mod.rs
+++ b/src/idle_inhibitor/wayland/mod.rs
@@ -17,8 +17,8 @@
 //! Connection to the Wayland compositor and manages the Wayland Idle Inhibitor.
 
 use std::collections::HashMap;
+use std::error::Error;
 use std::os::fd::AsFd;
-use std::{error::Error, fmt::Display};
 
 use wayland_client::backend::{ObjectId, ReadEventsGuard};
 use wayland_client::protocol::wl_buffer;
@@ -128,7 +128,7 @@ impl WaylandIdleInhibitor {
             Ok(self
                 .event_queue
                 .prepare_read()
-                .ok_or(WaylandIdleInhibitorError::WlEventQueueUnkownErrorOnReadLock)?)
+                .ok_or("Unknown error when trying to get a read lock on the Wayland Event Queue")?)
         }
     }
 
@@ -502,24 +502,3 @@ delegate_noop!(WaylandState: ZwlrLayerShellV1);
 delegate_noop!(WaylandState: ignore WlSurface);
 delegate_noop!(WaylandState: ignore WlShm);
 delegate_noop!(WaylandState: ignore WlOutput);
-
-// Module Error type
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum WaylandIdleInhibitorError {
-    WlEventQueueUnkownErrorOnReadLock,
-}
-
-impl Display for WaylandIdleInhibitorError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            WaylandIdleInhibitorError::WlEventQueueUnkownErrorOnReadLock => {
-                "Unknown error when trying to get a read lock on the Wayland Event Queue"
-                    .to_string()
-                    .fmt(f)
-            }
-        }
-    }
-}
-
-impl Error for WaylandIdleInhibitorError {}

--- a/src/idle_inhibitor/wayland/mod.rs
+++ b/src/idle_inhibitor/wayland/mod.rs
@@ -96,9 +96,7 @@ impl WaylandIdleInhibitor {
         let (global_list, mut event_queue) = registry_queue_init::<Self>(&connection)?;
         let qhandle = event_queue.handle();
 
-        // TODO: Set sane versions for each interface. Versions should be from the minimal
-        // necessary
-        let compositor: WlCompositor = global_list.bind(&qhandle, 6..=6, ())?;
+        let compositor: WlCompositor = global_list.bind(&qhandle, 1..=1, ())?;
         let shm: WlShm = global_list.bind(&qhandle, 1..=1, ())?;
         let wlr_layer_shell: ZwlrLayerShellV1 = global_list.bind(&qhandle, 1..=1, ())?;
         let idle_inhibit_manager: ZwpIdleInhibitManagerV1 =
@@ -114,7 +112,7 @@ impl WaylandIdleInhibitor {
                 if global.interface == WlOutput::interface().name {
                     Some((
                         global.name,
-                        Output::new(registry.bind(global.name, global.version, &qhandle, ())),
+                        Output::new(registry.bind(global.name, 1, &qhandle, ())),
                     ))
                 } else {
                     None
@@ -407,14 +405,12 @@ impl Dispatch<WlRegistry, GlobalListContents> for WaylandIdleInhibitor {
     ) {
         match event {
             wl_registry::Event::Global {
-                name,
-                interface,
-                version,
+                name, interface, ..
             } => {
-                log::trace!(target: "WaylandIdleInhibitor::WlRegistry::Event::Global", "New {} [{}] v{}", interface, name, version);
+                log::trace!(target: "WaylandIdleInhibitor::WlRegistry::Event::Global", "New {} [{}] v{}", interface, name, 1);
                 if interface == WlOutput::interface().name {
                     log::debug!(target: "WaylandIdleInhibitor::WlRegistry::Event::Global", "New output {}", name);
-                    let wl_output = proxy.bind(name, version, qhandle, ());
+                    let wl_output = proxy.bind(name, 1, qhandle, ());
                     state.outputs.insert(name, Output::new(wl_output));
                     state.init_missing_surfaces();
                 }

--- a/src/idle_inhibitor/wayland/mod.rs
+++ b/src/idle_inhibitor/wayland/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024  Rafael Carvalho <contact@rafaelrc.com>
+// Copyright (C) 2023-2025  Rafael Carvalho <contact@rafaelrc.com>
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 3 as published by
@@ -11,27 +11,27 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-//
+
 // SPDX-License-Identifier: GPL-3.0-only
 
 //! Connection to the Wayland compositor and manages the Wayland Idle Inhibitor.
 
-use std::error::Error;
 use std::io::Write;
 use std::os::fd::AsFd;
+use std::{error::Error, fmt::Display};
 
 use wayland_client::{
     delegate_noop,
+    globals::{registry_queue_init, GlobalList, GlobalListContents},
     protocol::{
         wl_buffer::WlBuffer,
         wl_compositor::WlCompositor,
-        wl_display::WlDisplay,
         wl_registry::{self, WlRegistry},
         wl_shm::{Format, WlShm},
         wl_shm_pool::WlShmPool,
         wl_surface::WlSurface,
     },
-    Connection, Dispatch, DispatchError, EventQueue, Proxy, QueueHandle,
+    Connection, Dispatch, EventQueue, Proxy, QueueHandle,
 };
 
 use wayland_protocols::wp::idle_inhibit::zv1::client::{
@@ -43,20 +43,93 @@ use wayland_protocols_wlr::layer_shell::v1::client::{
     zwlr_layer_surface_v1::{self, ZwlrLayerSurfaceV1},
 };
 
-use log::{debug, info, warn};
+use log::{debug, info, trace, warn};
 
 use tempfile;
 
 use super::IdleInhibitor;
 
-/// Wrapper to the Wayland objects and the idle inhibitor protocol
+/// Wrapper to the Wayland objects and event queue
 pub struct WaylandIdleInhibitor {
-    _connection: Connection,
-    _display: WlDisplay,
-    event_queue: EventQueue<AppData>,
-    qhandle: QueueHandle<AppData>,
-    _registry: WlRegistry,
-    data: AppData,
+    event_queue: EventQueue<State>,
+    state: State,
+}
+
+/// Wayland globals and surface
+struct State {
+    compositor: WlCompositor,
+    shm: WlShm,
+    wlr_layer_shell: ZwlrLayerShellV1,
+    idle_inhibit_manager: ZwpIdleInhibitManagerV1,
+    surface: Option<Surface>,
+}
+
+/// Relevant surface objects that depend on each other, thus are represented in a single struct
+struct Surface {
+    wl_surface: WlSurface,
+    wlr_layer_surface: ZwlrLayerSurfaceV1,
+    idle_inhibitor: Option<ZwpIdleInhibitorV1>,
+    configured: bool,
+}
+
+impl WaylandIdleInhibitor {
+    /// Creates an instance, including a surface, and fires and treats initial events
+    pub fn new() -> Result<Self, Box<dyn Error>> {
+        let connection = Connection::connect_to_env()?;
+        let (global_list, event_queue) = registry_queue_init::<State>(&connection)?;
+        let qhandle = &event_queue.handle();
+
+        let mut state = State::new(&global_list, qhandle)?;
+        state.init_new_surface(qhandle);
+
+        let mut wayland_idle_inhibitor = Self { event_queue, state };
+
+        wayland_idle_inhibitor.roundtrip()?;
+
+        let Some(surface) = &wayland_idle_inhibitor.state.surface else {
+            warn!(target: "WaylandIdleInhibitor::new", "Missing surface");
+            return Err(WaylandIdleInhibitorError::WlSurfaceNotCreated.into());
+        };
+
+        surface.create_and_attach_buffer(&wayland_idle_inhibitor.state, qhandle)?;
+
+        debug!(target: "WaylandIdleInhibitor::new", "Instance built");
+        Ok(wayland_idle_inhibitor)
+    }
+
+    /// Fires enqueued Wayland events to be treated
+    fn roundtrip(&mut self) -> Result<usize, wayland_client::DispatchError> {
+        self.event_queue.roundtrip(&mut self.state)
+    }
+
+    /// Enables or disables Idle inhibiting using the Wayland protocol
+    pub fn set_inhibit_idle(&mut self, inhibit_idle: bool) -> Result<(), Box<dyn Error>> {
+        let state = &mut self.state;
+        let qhandle = &self.event_queue.handle();
+        let Some(surface) = &mut state.surface else {
+            warn!(target: "WaylandIdleInhibitor::set_inhibit_idle", "Tried to change idle inhibitor status without loaded WlSurface!");
+            return Ok(());
+        };
+
+        if inhibit_idle {
+            if surface.idle_inhibitor.is_none() {
+                surface.idle_inhibitor = Some(state.idle_inhibit_manager.create_inhibitor(
+                    &surface.wl_surface,
+                    qhandle,
+                    (),
+                ));
+                self.roundtrip()?;
+                info!(target: "WaylandIdleInhibitor::set_inhibit_idle", "Idle Inhibitor was ENABLED");
+            }
+        } else if let Some(idle_inhibitor) = &surface.idle_inhibitor {
+            idle_inhibitor.destroy();
+            surface.idle_inhibitor = None;
+            self.roundtrip()?;
+            info!(target: "WaylandIdleInhibitor::set_inhibit_idle", "Idle Inhibitor was DISABLED");
+        }
+
+        Ok(())
+    }
 }
 
 impl IdleInhibitor for WaylandIdleInhibitor {
@@ -69,154 +142,137 @@ impl IdleInhibitor for WaylandIdleInhibitor {
     }
 }
 
-impl WaylandIdleInhibitor {
-    /// Builds the connection struct and fires the initial events, necessary to receive and store
-    /// wayland objects
-    pub fn new() -> Result<Self, Box<dyn Error>> {
-        let connection = Connection::connect_to_env()?;
-        let display = connection.display();
-        let event_queue = connection.new_event_queue();
-        let qhandle = event_queue.handle();
-        let registry = display.get_registry(&qhandle, ());
+impl State {
+    /// Creates an instance by going through the globals list and binding the relevant ones. Does
+    /// not create a surface.
+    fn new(global_list: &GlobalList, qhandle: &QueueHandle<State>) -> Result<Self, Box<dyn Error>> {
+        let compositor: WlCompositor = global_list.bind(qhandle, 6..=6, ())?;
+        let shm: WlShm = global_list.bind(qhandle, 1..=1, ())?;
+        let wlr_layer_shell: ZwlrLayerShellV1 = global_list.bind(qhandle, 1..=1, ())?;
+        let idle_inhibit_manager: ZwpIdleInhibitManagerV1 = global_list.bind(qhandle, 1..=1, ())?;
 
-        let mut obj = Self {
-            _connection: connection,
-            _display: display,
-            event_queue,
-            qhandle,
-            _registry: registry,
-            data: AppData::default(),
-        };
-        obj.initialize()?;
-        Ok(obj)
+        Ok(Self {
+            compositor,
+            shm,
+            wlr_layer_shell,
+            idle_inhibit_manager,
+            surface: None,
+        })
     }
 
-    fn init_buffer(&mut self) {
-        let mut file = tempfile::tempfile().unwrap();
-        let shm = self
-            .data
-            .shm
-            .as_ref()
-            .expect("WlShm global not initialized");
+    /// Create a new surface, destroying the current one if it exists.
+    fn init_new_surface(&mut self, qhandle: &QueueHandle<State>) {
+        self.surface = Some(Surface::new(self, qhandle));
+    }
+}
+
+impl Surface {
+    /// Creates an instance. It must receive a [zwlr_layer_surface_v1::Event::Configure] event
+    /// before the buffer is created and attached
+    fn new(state: &State, qhandle: &QueueHandle<State>) -> Self {
+        let wl_surface = state.compositor.create_surface(qhandle, ());
+        let wlr_layer_surface = state.wlr_layer_shell.get_layer_surface(
+            &wl_surface,
+            None,
+            Layer::Background,
+            "wayland-pipewire-idle-inhibit".into(),
+            qhandle,
+            (),
+        );
+        wlr_layer_surface.set_anchor(zwlr_layer_surface_v1::Anchor::all());
+        wl_surface.commit();
+
+        Self {
+            wl_surface,
+            wlr_layer_surface,
+            idle_inhibitor: None,
+            configured: false,
+        }
+    }
+
+    /// Creates and attaches a buffer for the surface
+    fn create_and_attach_buffer(
+        &self,
+        state: &State,
+        qhandle: &QueueHandle<State>,
+    ) -> Result<(), Box<dyn Error>> {
         let width = 1;
         let height = 1;
         let stride = width * 4;
         let pool_size = height * stride * 2;
-        let pool = shm.create_pool(file.as_fd(), pool_size, &self.qhandle, ());
-        let buffer = pool.create_buffer(
-            0,
-            width,
-            height,
-            stride,
-            Format::Argb8888,
-            &self.qhandle,
-            (),
-        );
-        let _ = file.write(b"\x00\x00\x00\x00\x00\x00\x00\x00");
-        self.data.buffer = Some(buffer);
-    }
 
-    fn init_layer_surface(&mut self) {
-        let layer_shell = self
-            .data
-            .layer_shell
-            .as_ref()
-            .expect("ZwlrLayerShellV1 global not initialized");
-        let surface = self.data.surface.as_ref().expect("WlSurface not created");
-        let layer_surface = layer_shell.get_layer_surface(
-            surface,
-            None,
-            Layer::Background,
-            "wayland-pipewire-idle-inhibit".to_string(),
-            &self.qhandle,
-            (),
-        );
-        layer_surface.set_anchor(zwlr_layer_surface_v1::Anchor::all());
-        surface.commit();
-        self.data.layer_surface = Some(layer_surface);
-    }
-
-    fn initialize(&mut self) -> Result<(), Box<dyn Error>> {
-        self.roundtrip()?; // init globals
-
-        self.init_buffer();
-        self.init_layer_surface();
-        self.roundtrip()?; // make sure layer_surface receives the configure event
-        let surface = self
-            .data
-            .surface
-            .as_ref()
-            .expect("WlSurface is not initialized");
-        let buffer = self
-            .data
-            .buffer
-            .as_ref()
-            .expect("WlBuffer is not initialized");
-
-        surface.attach(Some(buffer), 0, 0);
-        surface.commit();
-        self.roundtrip()?;
-
-        Ok(())
-    }
-
-    /// Fires enqueued Wayland events to be treated
-    pub fn roundtrip(&mut self) -> Result<usize, DispatchError> {
-        self.event_queue.roundtrip(&mut self.data)
-    }
-
-    /// Enables or disables Idle inhibiting using the Wayland protocol
-    pub fn set_inhibit_idle(&mut self, inhibit_idle: bool) -> Result<(), Box<dyn Error>> {
-        let data = &self.data;
-        let Some((idle_manager, _)) = &data.idle_manager else {
-            warn!(target: "WaylandIdleInhibitor::set_inhibit_idle", "Tried to change idle inhibitor status without loaded idle inhibitor manager!");
-            return Ok(());
-        };
-
-        if inhibit_idle {
-            if data.idle_inhibitor.is_none() {
-                let Some(surface) = &data.surface else {
-                    warn!(target: "WaylandIdleInhibitor::set_inhibit_idle", "Tried to change idle inhibitor status without loaded WlSurface!");
-                    return Ok(());
-                };
-                self.data.idle_inhibitor =
-                    Some(idle_manager.create_inhibitor(surface, &self.qhandle, ()));
-                self.roundtrip()?;
-                info!(target: "WaylandIdleInhibitor::set_inhibit_idle", "Idle Inhibitor was ENABLED");
-            }
-        } else if let Some(indle_inhibitor) = &self.data.idle_inhibitor {
-            indle_inhibitor.destroy();
-            self.data.idle_inhibitor = None;
-            self.roundtrip()?;
-            info!(target: "WaylandIdleInhibitor::set_inhibit_idle", "Idle Inhibitor was DISABLED");
+        if !self.configured {
+            warn!(target: "WaylandIdleInhibitor::create_and_attach_buffer",
+                "WLR Layer Surface did not receive the configure event!");
+            return Err(WaylandIdleInhibitorError::WlrLayerSurfaceNotConfigured.into());
         }
+
+        let mut file = tempfile::tempfile()?;
+        file.write_all(b"\x00\x00\x00\x00\x00\x00\x00\x00")?;
+
+        let pool = state.shm.create_pool(file.as_fd(), pool_size, qhandle, ());
+        let buffer = pool.create_buffer(0, width, height, stride, Format::Argb8888, qhandle, ());
+
+        self.wl_surface.attach(Some(&buffer), 0, 0);
+        self.wl_surface.commit();
 
         Ok(())
     }
 }
 
-/// Wayland connection and main objects
-#[derive(Default)]
-struct AppData {
-    compositor: Option<(WlCompositor, u32)>,
-    surface: Option<WlSurface>,
-    shm: Option<WlShm>,
-    buffer: Option<WlBuffer>,
-    layer_shell: Option<ZwlrLayerShellV1>,
-    layer_surface: Option<ZwlrLayerSurfaceV1>,
-    idle_manager: Option<(ZwpIdleInhibitManagerV1, u32)>,
-    idle_inhibitor: Option<ZwpIdleInhibitorV1>,
+impl Drop for Surface {
+    fn drop(&mut self) {
+        if let Some(idle_inhibitor) = &self.idle_inhibitor {
+            idle_inhibitor.destroy();
+            self.idle_inhibitor = None;
+        }
+        self.wlr_layer_surface.destroy();
+        self.wl_surface.destroy();
+    }
+}
+
+/// Subscribes to the [ZwlrLayerSurfaceV1] events waiting for configure and closed events.
+impl Dispatch<ZwlrLayerSurfaceV1, ()> for State {
+    fn event(
+        state: &mut Self,
+        proxy: &ZwlrLayerSurfaceV1,
+        event: <ZwlrLayerSurfaceV1 as Proxy>::Event,
+        _data: &(),
+        _conn: &Connection,
+        _qhandle: &QueueHandle<Self>,
+    ) {
+        match event {
+            zwlr_layer_surface_v1::Event::Configure { serial, .. } => {
+                trace!(target: "WaylandIdleInhibitor::ZwlrLayerSurfaceV1::Event::Configure", "WLR Layer Surface Configure Event received");
+                if let Some(surface) = &mut state.surface {
+                    proxy.ack_configure(serial);
+                    surface.configured = true;
+                    debug!(target: "WaylandIdleInhibitor::ZwlrLayerSurfaceV1::Event::Configure", "WLR Layer Surface configured");
+                } else {
+                    warn!(target: "WaylandIdleInhibitor::ZwlrLayerSurfaceV1::Event::Configure",
+                        "WLR Layer Surface Configure Event received but Surface is missing!");
+                }
+            }
+
+            zwlr_layer_surface_v1::Event::Closed => {
+                warn!(target: "WaylandIdleInhibitor::ZwlrLayerSurfaceV1::Event::Closed", "WLR Layer Surface was closed");
+                state.surface = None;
+            }
+
+            _ => unreachable!(),
+        }
+    }
 }
 
 /// Subscribes to the [WlRegistry] events, mainly to treat added and removed objects
-impl Dispatch<WlRegistry, ()> for AppData {
+impl Dispatch<WlRegistry, GlobalListContents> for State {
     fn event(
-        state: &mut Self,
-        proxy: &WlRegistry,
-        event: <WlRegistry as wayland_client::Proxy>::Event,
-        _data: &(),
-        _conn: &wayland_client::Connection,
-        qhandle: &wayland_client::QueueHandle<Self>,
+        _state: &mut Self,
+        _proxy: &WlRegistry,
+        event: <WlRegistry as Proxy>::Event,
+        _data: &GlobalListContents,
+        _conn: &Connection,
+        _qhandle: &QueueHandle<Self>,
     ) {
         match event {
             wl_registry::Event::Global {
@@ -224,66 +280,45 @@ impl Dispatch<WlRegistry, ()> for AppData {
                 interface,
                 version,
             } => {
-                if interface == WlCompositor::interface().name && state.compositor.is_none() {
-                    debug!(target: "WaylandIdleInhibitor::WlRegistry::Event::Global", "Adding Compositor with name {name} and version {version}");
-                    let compositor: WlCompositor = proxy.bind(name, version, qhandle, ());
-                    state.surface = Some(compositor.create_surface(qhandle, ()));
-                    state.compositor = Some((compositor, name));
-                } else if interface == WlShm::interface().name {
-                    state.shm = Some(proxy.bind(name, version, qhandle, ()));
-                } else if interface == ZwlrLayerShellV1::interface().name
-                    && state.layer_shell.is_none()
-                {
-                    state.layer_shell = Some(proxy.bind(name, version, qhandle, ()));
-                } else if interface == ZwpIdleInhibitManagerV1::interface().name
-                    && state.idle_manager.is_none()
-                {
-                    debug!(target: "WaylandIdleInhibitor::WlRegistry::Event::Global", "Adding IdleInhibitManager with name {name} and version {version}");
-                    state.idle_manager = Some((proxy.bind(name, version, qhandle, ()), name));
-                };
+                trace!(target: "WaylandIdleInhibitor::WlRegistry::Event::Global", "New {} [{}] v{}", interface, name, version);
             }
             wl_registry::Event::GlobalRemove { name } => {
-                if let Some((_, compositor_name)) = &state.compositor {
-                    if name == *compositor_name {
-                        warn!(target: "WaylandIdleInhibitor::GlobalRemove", "Compositor was removed!");
-                        state.compositor = None;
-                        state.surface = None;
-                    }
-                } else if let Some((_, idle_manager_name)) = &state.idle_manager {
-                    if name == *idle_manager_name {
-                        warn!(target: "WaylandIdleInhibitor::GlobalRemove", "IdleInhibitManager was removed!");
-                        state.idle_manager = None;
-                    }
-                }
+                trace!(target: "WaylandIdleInhibitor::WlRegistry::Event::Global", "Removed {}", name);
             }
-            _ => {}
-        }
-    }
-}
-
-impl Dispatch<ZwlrLayerSurfaceV1, ()> for AppData {
-    fn event(
-        _state: &mut Self,
-        proxy: &ZwlrLayerSurfaceV1,
-        _event: <ZwlrLayerSurfaceV1 as Proxy>::Event,
-        _data: &(),
-        _conn: &Connection,
-        _qhandle: &QueueHandle<Self>,
-    ) {
-        if let zwlr_layer_surface_v1::Event::Configure { serial, .. } = _event {
-            proxy.ack_configure(serial);
+            _ => unreachable!(),
         }
     }
 }
 
 // These interfaces have no events.
-delegate_noop!(AppData: WlCompositor);
-delegate_noop!(AppData: ZwpIdleInhibitManagerV1);
-delegate_noop!(AppData: ZwpIdleInhibitorV1);
-delegate_noop!(AppData: WlShmPool);
-delegate_noop!(AppData: ZwlrLayerShellV1);
+delegate_noop!(State: WlCompositor);
+delegate_noop!(State: ZwpIdleInhibitManagerV1);
+delegate_noop!(State: ZwpIdleInhibitorV1);
+delegate_noop!(State: WlShmPool);
+delegate_noop!(State: ZwlrLayerShellV1);
 
 // Ignore events from these object types.
-delegate_noop!(AppData: ignore WlSurface);
-delegate_noop!(AppData: ignore WlBuffer);
-delegate_noop!(AppData: ignore WlShm);
+delegate_noop!(State: ignore WlSurface);
+delegate_noop!(State: ignore WlBuffer);
+delegate_noop!(State: ignore WlShm);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum WaylandIdleInhibitorError {
+    WlrLayerSurfaceNotConfigured,
+    WlSurfaceNotCreated,
+}
+
+impl Display for WaylandIdleInhibitorError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WaylandIdleInhibitorError::WlrLayerSurfaceNotConfigured => {
+                "WLR Layer Surface was not configured!".to_string().fmt(f)
+            }
+            WaylandIdleInhibitorError::WlSurfaceNotCreated => {
+                "Wayland Surface was not created!".to_string().fmt(f)
+            }
+        }
+    }
+}
+
+impl Error for WaylandIdleInhibitorError {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024  Rafael Carvalho <contact@rafaelrc.com>
+// Copyright (C) 2023-2025  Rafael Carvalho <contact@rafaelrc.com>
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 3 as published by
@@ -11,13 +11,13 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-//
+
 // SPDX-License-Identifier: GPL-3.0-only
 
 //! Inhibit idle in Wayland compositors when audio is being played through PipeWire, with highly
 //! customisable options
 
-use std::{sync::mpsc, thread};
+use std::thread;
 
 use signal_hook::{consts::TERM_SIGNALS, iterator::Signals};
 
@@ -35,7 +35,29 @@ use idle_inhibitor::{
 mod settings;
 use settings::Settings;
 
-#[derive(Debug)]
+mod message_queue;
+
+use nix::{errno::Errno, sys::epoll::*};
+
+#[repr(u64)]
+enum MessageQueueType {
+    WaylandQueue,
+    MainQueue,
+}
+
+impl TryFrom<u64> for MessageQueueType {
+    type Error = ();
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        match value {
+            value if value == Self::WaylandQueue as u64 => Ok(Self::WaylandQueue),
+            value if value == Self::MainQueue as u64 => Ok(Self::MainQueue),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
 enum Msg {
     PWEvent(PWEvent),
     InhibitIdleStateEvent(InhibitIdleStateEvent),
@@ -68,20 +90,22 @@ fn main() {
     )
     .unwrap();
 
-    let (event_queue_sender, event_queue) = mpsc::channel::<Msg>();
+    let epoll = Epoll::new(EpollCreateFlags::empty()).unwrap();
+    let (mq, mq_receiver) =
+        message_queue::message_queue::<Msg>(&epoll, MessageQueueType::MainQueue as u64).unwrap();
 
     let mut signals = Signals::new(TERM_SIGNALS).expect("Failed to create signal listener");
     let signal_thread = thread::spawn({
-        let event_queue_sender = event_queue_sender.clone();
+        let mq = mq.clone();
         move || {
             for _sig in signals.wait() {
-                event_queue_sender.send(Msg::Terminate).unwrap();
+                mq.send(Msg::Terminate).unwrap();
             }
         }
     });
 
     let pw_thread = PWThread::new(
-        event_queue_sender.clone(),
+        mq.clone(),
         settings.get_sink_whitelist().to_vec(),
         settings.get_node_blacklist().to_vec(),
     );
@@ -99,41 +123,78 @@ fn main() {
     };
 
     let mut inhibit_idle_state_manager: InhibitIdleState<Msg> =
-        InhibitIdleState::new(settings.get_media_minimum_duration(), event_queue_sender);
+        InhibitIdleState::new(settings.get_media_minimum_duration(), mq.clone());
 
     loop {
-        match event_queue.recv().unwrap() {
-            Msg::PWEvent(pw_event) => match pw_event {
-                PWEvent::GraphUpdated => {
-                    pw_thread.send(PWMsg::GraphUpdated).unwrap();
+        let wayland_read_guard = idle_inhibitor.wayland_queue_read_guard().unwrap();
+        if let Some(wayland_read_guard) = &wayland_read_guard {
+            epoll
+                .add(
+                    wayland_read_guard.connection_fd(),
+                    EpollEvent::new(EpollFlags::EPOLLIN, MessageQueueType::WaylandQueue as u64),
+                )
+                .unwrap();
+        }
+        let event = epoll_wait(&epoll).unwrap();
+        match event.data().try_into() {
+            Ok(MessageQueueType::MainQueue) => {
+                if let Some(wayland_read_guard) = wayland_read_guard {
+                    epoll.delete(wayland_read_guard.connection_fd()).unwrap();
+                    std::mem::drop(wayland_read_guard);
                 }
-
-                PWEvent::InhibitIdleState(inhibit_idle_state) => {
-                    inhibit_idle_state_manager.set_is_idle_inhibited(inhibit_idle_state);
-                }
-            },
-
-            Msg::InhibitIdleStateEvent(inhibit_idle_state_event) => {
-                match inhibit_idle_state_event {
-                    InhibitIdleStateEvent::InhibitIdle(inhibit_idle_state) => {
-                        if let Err(error) = if inhibit_idle_state {
-                            idle_inhibitor.inhibit()
-                        } else {
-                            idle_inhibitor.uninhibit()
-                        } {
-                            panic!("{}", error);
+                match mq_receiver.recv().unwrap() {
+                    Msg::PWEvent(pw_event) => match pw_event {
+                        PWEvent::GraphUpdated => {
+                            pw_thread.send(PWMsg::GraphUpdated).unwrap();
                         }
+
+                        PWEvent::InhibitIdleState(inhibit_idle_state) => {
+                            inhibit_idle_state_manager.set_is_idle_inhibited(inhibit_idle_state);
+                        }
+                    },
+
+                    Msg::InhibitIdleStateEvent(inhibit_idle_state_event) => {
+                        match inhibit_idle_state_event {
+                            InhibitIdleStateEvent::InhibitIdle(inhibit_idle_state) => {
+                                if let Err(error) = if inhibit_idle_state {
+                                    idle_inhibitor.inhibit()
+                                } else {
+                                    idle_inhibitor.uninhibit()
+                                } {
+                                    panic!("{}", error);
+                                }
+                            }
+                        }
+                    }
+
+                    Msg::Terminate => {
+                        pw_thread.send(PWMsg::Terminate).unwrap();
+                        break;
                     }
                 }
             }
 
-            Msg::Terminate => {
-                pw_thread.send(PWMsg::Terminate).unwrap();
-                break;
+            Ok(MessageQueueType::WaylandQueue) => {
+                if let Some(wayland_read_guard) = wayland_read_guard {
+                    epoll.delete(wayland_read_guard.connection_fd()).unwrap();
+                    wayland_read_guard.read().unwrap();
+                    idle_inhibitor.wayland_dispatch_pending().unwrap();
+                }
             }
+
+            _ => log::error!(target: "main", "Unknown event queue"),
         }
     }
 
     pw_thread.join().unwrap();
     signal_thread.join().unwrap();
+}
+
+fn epoll_wait(epoll: &Epoll) -> Result<EpollEvent, Errno> {
+    let mut events = [EpollEvent::empty()];
+    match epoll.wait(&mut events, EpollTimeout::NONE) {
+        Ok(_) => Ok(events[0]),
+        Err(Errno::EINTR) => epoll_wait(epoll),
+        Err(err) => Err(err),
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,11 +30,15 @@ mod inhibit_idle_state;
 use inhibit_idle_state::{InhibitIdleState, InhibitIdleStateEvent};
 
 mod pipewire_connection;
+use message_queue::MessageQueueReceiver;
 use pipewire_connection::{PWEvent, PWMsg, PWThread};
 
 mod idle_inhibitor;
 use idle_inhibitor::{
-    dbus::DbusIdleInhibitor, dry::DryRunIdleInhibitor, wayland::WaylandIdleInhibitor, IdleInhibitor,
+    dbus::DbusIdleInhibitor,
+    dry::DryRunIdleInhibitor,
+    wayland::{WaylandEventQueue, WaylandIdleInhibitor},
+    IdleInhibitor,
 };
 
 mod settings;
@@ -66,6 +70,40 @@ impl TryFrom<u64> for MessageQueueType {
 enum Msg {
     PWEvent(PWEvent),
     InhibitIdleStateEvent(InhibitIdleStateEvent),
+}
+
+impl Msg {
+    fn handle(
+        &self,
+        pw_thread: &PWThread,
+        inhibit_idle_state_manager: &mut InhibitIdleState<Msg>,
+        idle_inhibitor: &mut dyn IdleInhibitor,
+    ) -> Result<(), Box<dyn Error>> {
+        match self {
+            Msg::PWEvent(pw_event) => match pw_event {
+                PWEvent::GraphUpdated => {
+                    pw_thread.send(PWMsg::GraphUpdated)?;
+                }
+
+                PWEvent::InhibitIdleState(inhibit_idle_state) => {
+                    inhibit_idle_state_manager.set_is_idle_inhibited(*inhibit_idle_state);
+                }
+            },
+
+            Msg::InhibitIdleStateEvent(inhibit_idle_state_event) => {
+                match inhibit_idle_state_event {
+                    InhibitIdleStateEvent::InhibitIdle(inhibit_idle_state) => {
+                        if *inhibit_idle_state {
+                            idle_inhibitor.inhibit()?;
+                        } else {
+                            idle_inhibitor.uninhibit()?;
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
 }
 
 impl From<PWEvent> for Msg {
@@ -110,13 +148,7 @@ fn run() -> Result<(), Box<dyn Error>> {
         settings.get_node_blacklist().to_vec(),
     );
 
-    let mut idle_inhibitor: Box<dyn IdleInhibitor> = match settings.get_idle_inhibitor() {
-        settings::IdleInhibitor::DBus => Box::new(DbusIdleInhibitor::new()?),
-        settings::IdleInhibitor::Wayland => Box::new(WaylandIdleInhibitor::new()?),
-        settings::IdleInhibitor::DryRun => Box::<DryRunIdleInhibitor>::default(),
-    };
-
-    let mut inhibit_idle_state_manager: InhibitIdleState<Msg> =
+    let inhibit_idle_state_manager: InhibitIdleState<Msg> =
         InhibitIdleState::new(settings.get_media_minimum_duration(), mq.clone());
 
     let term = Arc::new(AtomicBool::new(false));
@@ -124,14 +156,74 @@ fn run() -> Result<(), Box<dyn Error>> {
         signal_hook::flag::register(*sig, Arc::clone(&term))?;
     }
 
-    while !term.load(atomic::Ordering::Relaxed) {
-        let wayland_read_guard = idle_inhibitor.wayland_queue_read_guard()?;
-        if let Some(wayland_read_guard) = &wayland_read_guard {
-            epoll.add(
-                wayland_read_guard.connection_fd(),
-                EpollEvent::new(EpollFlags::EPOLLIN, MessageQueueType::WaylandQueue as u64),
+    match settings.get_idle_inhibitor() {
+        settings::IdleInhibitor::DBus => {
+            let idle_inhibitor = Box::new(DbusIdleInhibitor::new()?);
+            non_wayland_main_loop(
+                idle_inhibitor,
+                term,
+                epoll,
+                mq_receiver,
+                &pw_thread,
+                inhibit_idle_state_manager,
             )?;
         }
+        settings::IdleInhibitor::DryRun => {
+            let idle_inhibitor = Box::<DryRunIdleInhibitor>::default();
+            non_wayland_main_loop(
+                idle_inhibitor,
+                term,
+                epoll,
+                mq_receiver,
+                &pw_thread,
+                inhibit_idle_state_manager,
+            )?;
+        }
+        settings::IdleInhibitor::Wayland => {
+            let (idle_inhibitor, event_queue) = WaylandIdleInhibitor::new()?;
+            wayland_main_loop(
+                idle_inhibitor,
+                event_queue,
+                term,
+                epoll,
+                mq_receiver,
+                &pw_thread,
+                inhibit_idle_state_manager,
+            )?;
+        }
+    };
+
+    pw_thread.send(PWMsg::Terminate)?;
+    pw_thread.join()?;
+
+    Ok(())
+}
+
+fn wayland_main_loop(
+    mut wayland_idle_inhibitor: WaylandIdleInhibitor,
+    mut wayland_event_queue: WaylandEventQueue,
+    term: Arc<AtomicBool>,
+    epoll: Epoll,
+    mq_receiver: MessageQueueReceiver<Msg>,
+    pw_thread: &PWThread,
+    mut inhibit_idle_state_manager: InhibitIdleState<Msg>,
+) -> Result<(), Box<dyn Error>> {
+    while !term.load(atomic::Ordering::Relaxed) {
+        wayland_event_queue.flush()?;
+        let wayland_read_guard =
+            if let Some(wayland_read_guard) = wayland_event_queue.prepare_read() {
+                wayland_read_guard
+            } else {
+                wayland_event_queue.dispatch_pending(&mut wayland_idle_inhibitor)?;
+                wayland_event_queue.prepare_read().ok_or(
+                    "Unknown error when trying to get a read lock on the Wayland Event Queue",
+                )?
+            };
+
+        epoll.add(
+            wayland_read_guard.connection_fd(),
+            EpollEvent::new(EpollFlags::EPOLLIN, MessageQueueType::WaylandQueue as u64),
+        )?;
 
         let mut events = [EpollEvent::empty()];
         let event = match epoll.wait(&mut events, EpollTimeout::NONE) {
@@ -142,50 +234,73 @@ fn run() -> Result<(), Box<dyn Error>> {
 
         match event.data().try_into() {
             Ok(MessageQueueType::MainQueue) => {
-                if let Some(wayland_read_guard) = wayland_read_guard {
-                    epoll.delete(wayland_read_guard.connection_fd())?;
-                    std::mem::drop(wayland_read_guard);
-                }
-                match mq_receiver.recv()? {
-                    Msg::PWEvent(pw_event) => match pw_event {
-                        PWEvent::GraphUpdated => {
-                            pw_thread.send(PWMsg::GraphUpdated)?;
-                        }
-
-                        PWEvent::InhibitIdleState(inhibit_idle_state) => {
-                            inhibit_idle_state_manager.set_is_idle_inhibited(inhibit_idle_state);
-                        }
-                    },
-
-                    Msg::InhibitIdleStateEvent(inhibit_idle_state_event) => {
-                        match inhibit_idle_state_event {
-                            InhibitIdleStateEvent::InhibitIdle(inhibit_idle_state) => {
-                                if inhibit_idle_state {
-                                    idle_inhibitor.inhibit()?;
-                                } else {
-                                    idle_inhibitor.uninhibit()?;
-                                }
-                            }
-                        }
-                    }
-                }
+                epoll.delete(wayland_read_guard.connection_fd())?;
+                std::mem::drop(wayland_read_guard);
+                mq_receiver.recv()?.handle(
+                    pw_thread,
+                    &mut inhibit_idle_state_manager,
+                    &mut wayland_idle_inhibitor,
+                )?;
             }
 
             Ok(MessageQueueType::WaylandQueue) => {
-                if let Some(wayland_read_guard) = wayland_read_guard {
-                    epoll.delete(wayland_read_guard.connection_fd())?;
-                    if wayland_read_guard.read().is_ok() {
-                        idle_inhibitor.wayland_dispatch_pending()?;
-                    }
+                epoll.delete(wayland_read_guard.connection_fd())?;
+                if wayland_read_guard.read().is_ok() {
+                    wayland_event_queue.dispatch_pending(&mut wayland_idle_inhibitor)?;
                 }
             }
 
             _ => log::error!(target: "main", "Unknown event queue"),
         }
     }
+    Ok(())
+}
 
-    pw_thread.send(PWMsg::Terminate)?;
-    pw_thread.join()?;
+fn non_wayland_main_loop(
+    mut idle_inhibitor: Box<dyn IdleInhibitor>,
+    term: Arc<AtomicBool>,
+    epoll: Epoll,
+    mq_receiver: MessageQueueReceiver<Msg>,
+    pw_thread: &PWThread,
+    mut inhibit_idle_state_manager: InhibitIdleState<Msg>,
+) -> Result<(), Box<dyn Error>> {
+    while !term.load(atomic::Ordering::Relaxed) {
+        let mut events = [EpollEvent::empty()];
+        let event = match epoll.wait(&mut events, EpollTimeout::NONE) {
+            Ok(_) => events[0],
+            Err(Errno::EINTR) => continue,
+            Err(err) => Err(err)?,
+        };
 
+        match event.data().try_into() {
+            Ok(MessageQueueType::MainQueue) => match mq_receiver.recv()? {
+                Msg::PWEvent(pw_event) => match pw_event {
+                    PWEvent::GraphUpdated => {
+                        pw_thread.send(PWMsg::GraphUpdated)?;
+                    }
+
+                    PWEvent::InhibitIdleState(inhibit_idle_state) => {
+                        inhibit_idle_state_manager.set_is_idle_inhibited(inhibit_idle_state);
+                    }
+                },
+
+                Msg::InhibitIdleStateEvent(inhibit_idle_state_event) => {
+                    match inhibit_idle_state_event {
+                        InhibitIdleStateEvent::InhibitIdle(inhibit_idle_state) => {
+                            if inhibit_idle_state {
+                                idle_inhibitor.inhibit()?;
+                            } else {
+                                idle_inhibitor.uninhibit()?;
+                            }
+                        }
+                    }
+                }
+            },
+
+            Ok(MessageQueueType::WaylandQueue) => {}
+
+            _ => log::error!(target: "main", "Unknown event queue"),
+        }
+    }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,8 +177,9 @@ fn main() {
             Ok(MessageQueueType::WaylandQueue) => {
                 if let Some(wayland_read_guard) = wayland_read_guard {
                     epoll.delete(wayland_read_guard.connection_fd()).unwrap();
-                    wayland_read_guard.read().unwrap();
-                    idle_inhibitor.wayland_dispatch_pending().unwrap();
+                    if wayland_read_guard.read().is_ok() {
+                        idle_inhibitor.wayland_dispatch_pending().unwrap();
+                    }
                 }
             }
 

--- a/src/message_queue.rs
+++ b/src/message_queue.rs
@@ -1,0 +1,75 @@
+// Copyright (C) 2025  Rafael Carvalho <contact@rafaelrc.com>
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as published by
+// the Free Software Foundation.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::{
+    error::Error,
+    sync::{mpsc, Arc},
+};
+
+use nix::sys::{
+    epoll::{Epoll, EpollEvent, EpollFlags},
+    eventfd::{self, EfdFlags, EventFd},
+};
+
+#[derive(Clone)]
+pub struct MessageQueueSender<T> {
+    sender: mpsc::Sender<T>,
+    eventfd: Arc<eventfd::EventFd>,
+}
+
+pub struct MessageQueueReceiver<T> {
+    receiver: mpsc::Receiver<T>,
+    eventfd: Arc<eventfd::EventFd>,
+}
+
+pub fn message_queue<T: Clone>(
+    epoll: &Epoll,
+    queue_id: u64,
+) -> Result<(MessageQueueSender<T>, MessageQueueReceiver<T>), Box<dyn Error>> {
+    let (sender, receiver) = mpsc::channel::<T>();
+
+    let eventfd = EventFd::from_flags(EfdFlags::EFD_SEMAPHORE)?;
+    epoll.add(&eventfd, EpollEvent::new(EpollFlags::EPOLLIN, queue_id))?;
+
+    let eventfd = Arc::new(eventfd);
+
+    let message_queue_sender = MessageQueueSender {
+        sender,
+        eventfd: eventfd.clone(),
+    };
+
+    let message_queue_receiver = MessageQueueReceiver {
+        receiver,
+        eventfd: eventfd.clone(),
+    };
+    log::debug!(target: "MessageQueue::new", "Created new message queue with ID {}", queue_id);
+    Ok((message_queue_sender, message_queue_receiver))
+}
+
+impl<'a, T: 'a + Clone> MessageQueueSender<T> {
+    pub fn send(&self, payload: T) -> Result<(), Box<dyn Error + 'a>> {
+        self.sender.send(payload)?;
+        self.eventfd.write(1)?;
+        Ok(())
+    }
+}
+
+impl<T: Clone> MessageQueueReceiver<T> {
+    pub fn recv(&self) -> Result<T, Box<dyn Error>> {
+        self.eventfd.read()?;
+        Ok(self.receiver.recv()?)
+    }
+}

--- a/src/pipewire_connection/mod.rs
+++ b/src/pipewire_connection/mod.rs
@@ -20,7 +20,6 @@
 //! The graph is used to detect if any connection to watched sinks is active.
 
 use std::{
-    any::Any,
     cell::RefCell,
     marker::Send,
     rc::Rc,
@@ -99,13 +98,17 @@ impl PWThread {
     /// Waits for PipeWire [MainLoop] to terminate
     ///
     /// As this function joins with the thread, it takes ownership of the [PWThread] value.
-    pub fn join(self) -> Result<(), Box<dyn Any + Send>> {
-        self.pw_thread.join()
+    pub fn join(self) -> Result<(), String> {
+        self.pw_thread
+            .join()
+            .map_err(|_| "Error joining PipeWire thread".into())
     }
 
     /// Sends message to PipeWire [MainLoop]
-    pub fn send(&self, msg: PWMsg) -> Result<(), PWMsg> {
-        self.pw_event_sender.send(msg)
+    pub fn send(&self, msg: PWMsg) -> Result<(), &str> {
+        self.pw_event_sender
+            .send(msg)
+            .map_err(|_| "Error sending message to PipeWire channel")
     }
 }
 


### PR DESCRIPTION
This PR refactors a lot of the wayland idle-inhibitor module. The main changes are:

- Use [wayland_client::globals](https://docs.rs/wayland-client/latest/wayland_client/globals/index.html) for a cleaner set-up
- Implement a new messaging system that can use [nix::sys::epoll](https://docs.rs/nix/latest/nix/sys/epoll/struct.Epoll.html) together of the [wayland_client::EventQueue](https://docs.rs/wayland-client/latest/wayland_client/struct.EventQueue.html#integrating-the-event-queue-with-other-sources-of-events).
- Implement destructors for the various Wayland Proxies 
- Implement proper multi-output support, so that monitors can be removed and added during runtime.