### PR TITLE
Waybar module feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,6 +271,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "backtrace"
+version = "0.3.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,6 +351,12 @@ name = "bytemuck"
 version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
+
+[[package]]
+name = "bytes"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
@@ -790,6 +826,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
 name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,6 +917,17 @@ dependencies = [
  "equivalent",
  "hashbrown 0.15.4",
  "serde",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -971,6 +1024,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
+name = "lock_api"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,6 +1062,26 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+dependencies = [
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "nix"
@@ -1071,6 +1154,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1097,6 +1189,29 @@ name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1257,6 +1372,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "ref-cast"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1304,6 +1428,12 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -1359,6 +1489,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -1514,6 +1650,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1637,6 +1783,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31d42176308937165701f50638db1c31586f183f1aab416268216577aec7306b"
 dependencies = [
  "chrono",
+]
+
+[[package]]
+name = "tokio"
+version = "1.47.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "io-uring",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "slab",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1873,7 +2050,7 @@ dependencies = [
 
 [[package]]
 name = "wayland-pipewire-idle-inhibit"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "clap",
@@ -1889,6 +2066,7 @@ dependencies = [
  "signal-hook",
  "simplelog",
  "timer",
+ "tokio",
  "wayland-client",
  "wayland-protocols 0.31.2",
  "wayland-protocols-wlr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "wayland-pipewire-idle-inhibit"
-version = "0.6.0"
-authors = ["Rafael Carvalho <contact@rafaelrc.com>"]
+version = "0.7.0"
+authors = ["Rafael Carvalho <contact@rafaelrc.com>", "Alanon202"]
 edition = "2021"
 license = "GPL-3.0-only"
 repository = "https://github.com/rafaelrc7/wayland-pipewire-idle-inhibit"
 readme = "README.md"
-description = "Inhibit wayland idle when computer is playing sound"
-keywords = ["pipewire", "wayland", "utility", "idle", "inhibit"]
+description = "Inhibit wayland idle when computer is playing sound, with manual toggle support in waybar module"
+keywords = ["pipewire", "wayland", "utility", "idle", "inhibit", "waybar"]
 categories = ["multimedia"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -27,6 +27,7 @@ serde_with = "3.7"
 signal-hook = "0.3"
 simplelog = "0.12"
 timer = "0.2"
+tokio = { version = "1", features = ["full"] }
 wayland-client = "0.31"
 wayland-protocols = { version = "0.31", features = ["unstable", "client"] }
 wayland-protocols-wlr = { version = "0.3.8", features = ["client"] }

--- a/src/dbus_service.rs
+++ b/src/dbus_service.rs
@@ -1,0 +1,54 @@
+// Copyright (C) 2023-2025  Rafael Carvalho <contact@rafaelrc.com>
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as published by
+// the Free Software Foundation.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// SPDX-License-Identifier: GPL-3.0-only
+
+use crate::message_queue::MessageQueueSender;
+use crate::Msg;
+use std::error::Error;
+use zbus::{interface, ConnectionBuilder};
+
+pub struct DbusService {
+    mq: MessageQueueSender<Msg>,
+}
+
+impl DbusService {
+    pub fn new(mq: MessageQueueSender<Msg>) -> Self {
+        Self { mq }
+    }
+}
+
+#[interface(name = "org.wayland.IdleInhibit.Control")]
+impl DbusService {
+    async fn toggle_manual(&self) {
+        log::debug!("D-Bus method 'ToggleManual' called.");
+        if let Err(e) = self.mq.send(Msg::ToggleManual) {
+            log::error!("Failed to send ToggleManual message: {}", e);
+        }
+    }
+}
+
+pub async fn start_dbus_service(mq: MessageQueueSender<Msg>) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let dbus_service = DbusService::new(mq);
+    let _connection = ConnectionBuilder::session()?
+        .name("org.wayland.IdleInhibit.Control")?
+        .serve_at("/org/wayland/IdleInhibit/Control", dbus_service)?
+        .build()
+        .await?;
+
+    log::info!("D-Bus service for manual toggle started successfully.");
+    std::future::pending::<()>().await;
+
+    Ok(())
+}


### PR DESCRIPTION
So basically what this adds is a very simple waybar module with two features:

1. Allows the user to click on the icon and manually toggle idle inhibit
2. Changes the icon automatically to signal when something else is inhibiting audio. 

I added 2. specifically for edge-cases when something is blocking idle, so that the user can know it’s happening. There’s a 5 second delay though, to prevent notification pings and the like from constantly toggling the state.

Now, several caveats:
1. I’m no programmer so the code is probably shi**y. It can probably be improved in terms of performance and neatness by someone that knows Rust better. The module is still small enough to be useable, though.
2. From my limited testing, everything plays nicely together, but more robust testing is probably warranted. Anything that uses PipeWire is detected, and anything using systemd should be as well.
3. I originally intended to make the icons user-configurable, but it turned out to be a huge pain in the a$$, so for now they’re hard-coded.

Here is the module I’m using:

```
    "custom/idle-inhibit": {
        "format": "{}",
        "return-type": "json",
        "exec": "wayland-pipewire-idle-inhibit",
        "on-click": "busctl --user call org.wayland.IdleInhibit.Control /org/wayland/IdleInhibit/Control org.wayland.IdleInhibit.Control ToggleManual",
    },
```

Since the icons are hard-coded I used emojis and placed it right in front of the system tray to easily fit in. This is a simple style.css for that:

```
#custom-idle-inhibit {
    padding: 0px 0px;
    margin-top: 0px;
    border: 0px;
}
```