### PR TITLE
Resolve service dependency order

### DIFF
--- a/wayland-pipewire-idle-inhibit.service
+++ b/wayland-pipewire-idle-inhibit.service
@@ -1,5 +1,7 @@
 [Install]
 WantedBy=graphical-session.target
+After=pipewire.service graphical-session.target
+Wants=pipewire.service
 
 [Service]
 ExecStart=wayland-pipewire-idle-inhibit


### PR DESCRIPTION
I thiiiiink this fixes #22 .

I noticed this behavior on my system - after rebooting, I noticed that my system would idle while watching a movie. When I checked the service state with `systemctl status --user wayland-pipewire-idle-inhibit.service`, I saw the service was running without errors, and logging inhibit behavior. Restarting the service with `systemctl restart --user wayland-pipewire-idle-inhibit.service` resolved this behavior.

I didn't end up debug logging anything, but ensuring that the session was established before starting the service resolves the failure to inhibit after a reboot.

Let me know if you need more information to ensure I'm solving the right problem :slightly_smiling_face: 