### PR TITLE
Add waybar integration with associated script

### DIFF
--- a/scripts/dbus_monitor.sh
+++ b/scripts/dbus_monitor.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+###############################################################################
+# Waybar Custom Module: Wayland-Pipewire-Idle-Inhibit Monitor
+#
+# DESCRIPTION:
+#   This script monitors the state of the wayland-pipewire-idle-inhibit service
+#   via D-Bus and outputs a JSON object compatible with Waybar's custom module.
+#   It tracks three distinct states:
+#     1. 'off': The inhibitor service is not running on the session bus.
+#     2. 'idle': Service is running, but idle inhibition is currently inactive.
+#     3. 'inhibited': Inhibition is active, distinguishing between 'Audio' 
+#        (automated) and 'Manual' (user-forced) triggers.
+#
+# DEPENDENCIES:
+#   - jq: For parsing JSON payloads from busctl.
+#   - systemd (busctl): To interface with the D-Bus session bus.
+#
+# WAYBAR CONFIGURATION EXAMPLE:
+#   "custom/idle-inhibit": {
+#       "return-type": "json",
+#       "format": "{icon}",
+#       "exec": "/path/to/this/script.sh",
+#       "format-icons": {
+#           "inhibited": "󰈈",
+#           "idle": "󰈉",
+#           "off": ""
+#       },
+#       "on-click": "busctl --user call com.rafaelrc.WaylandPipewireIdleInhibit /com/rafaelrc/WaylandPipewireIdleInhibit com.rafaelrc.WaylandPipewireIdleInhibit ToggleManualInhibit"
+#   }
+###############################################################################
+
+# Configuration
+SERVICE="com.rafaelrc.WaylandPipewireIdleInhibit"
+OBJECT="/com/rafaelrc/WaylandPipewireIdleInhibit"
+INTERFACE="com.rafaelrc.WaylandPipewireIdleInhibit"
+
+# Function to format and output JSON for Waybar
+print_status() {
+    local idle_inhibited=$1
+    local manual_inhibited=$2
+
+    local tooltip=""
+    local class=""
+    local alt=""
+
+    # Output if the inhibitor is not running
+    if [ "$idle_inhibited" == "off" ]; then
+        echo '{"alt": "off", "tooltip": "wayland-pipewire-idle-inhibit not running", "class": "off"}'
+        return
+    fi
+
+    if [ "$idle_inhibited" == "true" ]; then
+        alt="inhibited"
+        if [ "$manual_inhibited" == "true" ]; then
+            tooltip="Idle Inhibitor: Active (Manual)"
+            class="manual"
+        else
+            tooltip="Idle Inhibitor: Active (Audio)"
+            class="inhibited"
+        fi
+    else
+        alt="idle"
+        tooltip="Idle Inhibitor: Inactive"
+        class="idle"
+    fi
+
+    # Output compressed JSON line
+    printf '{"alt": "%s", "tooltip": "%s", "class": "%s"}\n' "$alt" "$tooltip" "$class"
+}
+
+# Get Initial State
+if busctl --user status "$SERVICE" &>/dev/null; then
+    # Properties are PascalCase by default in zbus
+    IS_IDLE=$(busctl --user get-property $SERVICE $OBJECT $INTERFACE IsIdleInhibited --json=short 2>/dev/null | jq -r '.data // "false"')
+    IS_MANUAL=$(busctl --user get-property $SERVICE $OBJECT $INTERFACE ManualInhibit --json=short 2>/dev/null | jq -r '.data // "false"')
+else
+    IS_IDLE="off"
+    IS_MANUAL="off"
+fi
+
+# Function to fetch and print the current state
+get_and_print_state() {
+    # Check if the service exists on the bus
+    if busctl --user status "$SERVICE" &>/dev/null; then
+        local idle=$(busctl --user get-property "$SERVICE" "$OBJECT" "$INTERFACE" IsIdleInhibited --json=short 2>/dev/null | jq -r '.data // "false"')
+        local manual=$(busctl --user get-property "$SERVICE" "$OBJECT" "$INTERFACE" ManualInhibit --json=short 2>/dev/null | jq -r '.data // "false"')
+        print_status "$idle" "$manual"
+    else
+        print_status "off" "off"
+    fi
+}
+
+# Output Initial State
+get_and_print_state
+
+# Monitor for changes. 
+# We monitor our service for signals it sends, and org.freedesktop.DBus for name owner changes.
+busctl --user monitor "$SERVICE" "org.freedesktop.DBus" --json=short | while read -r line; do
+    # Detect if our service starts or stops (NameOwnerChanged signal from the bus)
+    if echo "$line" | jq -e ".member == \"NameOwnerChanged\" and .payload.data[0] == \"$SERVICE\"" >/dev/null; then
+        get_and_print_state
+    
+    elif echo "$line" | jq -e ".member == \"PropertiesChanged\" and .path == \"$OBJECT\"" >/dev/null; then
+        NEW_IDLE="$(echo "$line" | jq -r '.payload.data[0].IsIdleInhibited.data')"
+        NEW_MANUAL="$(echo "$line" | jq -r '.payload.data[0].IsManuallyInhibited.data')"
+        
+        if [[ -n "$NEW_IDLE" && -n "$NEW_MANUAL" ]]; then
+            print_status "$NEW_IDLE" "$NEW_MANUAL"
+        else
+            # Fallback to manual poll if payload parsing fails
+            get_and_print_state
+        fi
+    fi
+done

--- a/scripts/dbus_monitor.sh
+++ b/scripts/dbus_monitor.sh
@@ -68,16 +68,6 @@ print_status() {
     printf '{"alt": "%s", "tooltip": "%s", "class": "%s"}\n' "$alt" "$tooltip" "$class"
 }
 
-# Get Initial State
-if busctl --user status "$SERVICE" &>/dev/null; then
-    # Properties are PascalCase by default in zbus
-    IS_IDLE=$(busctl --user get-property $SERVICE $OBJECT $INTERFACE IsIdleInhibited --json=short 2>/dev/null | jq -r '.data // "false"')
-    IS_MANUAL=$(busctl --user get-property $SERVICE $OBJECT $INTERFACE ManualInhibit --json=short 2>/dev/null | jq -r '.data // "false"')
-else
-    IS_IDLE="off"
-    IS_MANUAL="off"
-fi
-
 # Function to fetch and print the current state
 get_and_print_state() {
     # Check if the service exists on the bus

--- a/src/dbus_server.rs
+++ b/src/dbus_server.rs
@@ -1,0 +1,81 @@
+// Copyright (C) 2023-2025  Rafael Carvalho <contact@rafaelrc.com>
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 as published by
+// the Free Software Foundation.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! Helper to manage the idle inhibiting state. This module is used to treat PipeWire events and
+//! send messages if and when idle should be inhibited, treating the minimum sound duration.
+
+use crate::message_queue::MessageQueueSender;
+use crate::Msg;
+use zbus::interface;
+
+pub struct DBusServer {
+    mq: MessageQueueSender<Msg>,
+    manual_inhibit: bool,
+    effective_inhibit: bool,
+}
+
+impl DBusServer {
+    pub fn new(mq: MessageQueueSender<Msg>) -> Self {
+        Self {
+            mq,
+            manual_inhibit: false,
+            effective_inhibit: false,
+        }
+    }
+
+    // Update the internal effective state for the D-Bus property
+    pub fn set_effective_inhibit(&mut self, value: bool) {
+        self.effective_inhibit = value;
+    }
+
+    pub fn get_effective_inhibit(&self) -> bool {
+        self.effective_inhibit
+    }
+
+    // Update the internal effective state for the D-Bus property
+    pub fn get_manual_inhibit(&self) -> bool {
+        self.manual_inhibit
+    }
+}
+
+#[interface(name = "com.rafaelrc.WaylandPipewireIdleInhibit")]
+impl DBusServer {
+    #[zbus(property)]
+    fn manual_inhibit(&self) -> bool {
+        self.manual_inhibit
+    }
+
+    #[zbus(property)]
+    fn set_manual_inhibit(&mut self, value: bool) {
+        if self.manual_inhibit != value {
+            self.manual_inhibit = value;
+            // Send message to the main loop to re-evaluate inhibition state
+            self.mq.send(Msg::ManualInhibit(value)).unwrap();
+        }
+    }
+
+    #[zbus()]
+    fn toggle_manual_inhibit(&mut self) {
+        let new_val = !self.manual_inhibit;
+        self.manual_inhibit = new_val;
+        self.mq.send(Msg::ManualInhibit(new_val)).unwrap();
+    }
+
+    #[zbus(property)]
+    fn is_idle_inhibited(&self) -> bool {
+        self.effective_inhibit
+    }
+}


### PR DESCRIPTION
This is (from my tests) a working implementation of what was discussed in #21. It uses dbus to emit a signal when `wayland-pipewire-idle-inhibit` is inhibiting idle either due to a manual toggle or sound being played. I also added a script under the new `scripts/`-folder which can be used from waybar.

**Disclaimer** A lot of this code is generated by AI, I have changed some things and reviewed as well as I could, but unfortunately my rust skills are just not there to do this within a reasonable time frame. I have tested and tweaked the behavior a lot and it behaves as it should.

One remaining topic is the paths/interfaces/service names for the dbus stuff. I am not really familiar with the naming conventions so I kind of guessed here.