### PR TITLE
Use node running state instead of link active state for detection

### DIFF
--- a/src/pipewire_connection/graph/mod.rs
+++ b/src/pipewire_connection/graph/mod.rs
@@ -384,19 +384,24 @@ impl PWGraph {
         false
     }
 
-    /// Transverses the Graphs in a manner similar to a DFS algorithm, looking for active
-    /// connections from sinks to nodes.
+    /// Transverses the Graphs in a manner similar to a DFS algorithm, looking for running
+    /// client nodes connected to sinks.
+    ///
+    /// Links are followed regardless of their active state, since passive filter chains
+    /// (e.g. WirePlumber software-dsp) never report links as active even when audio is
+    /// flowing. Instead, the running state of the leaf client node is checked.
     ///
     /// If a node_blacklist was passed, nodes that match it will be ignored.
     fn does_sink_has_active_nodes(&self, id: &Id, visited: &mut HashSet<Id>) -> bool {
         visited.insert(*id);
 
         trace!(target: "PWGraph::does_sink_has_active_nodes", "Node {id}");
-        match self.get(id) {
+        let node_data = match self.get(id) {
             Some(PWObject::Node { data, .. }) => {
                 if NodeFilter::matches_any(&self.node_blacklist, data) {
                     return false;
                 }
+                data
             }
             None => {
                 warn!(target: "PWGraph::does_sink_has_active_nodes", "While transversing graph, got invalid id {id}");
@@ -409,13 +414,13 @@ impl PWGraph {
         };
 
         let Some(node_input_ports) = self.node_input_ports.get(id) else {
-            trace!(target: "PWGraph::does_sink_has_active_nodes", "Node ({id}) has no input ports, assuming it is a client");
-            return true;
+            trace!(target: "PWGraph::does_sink_has_active_nodes", "Node ({id}) has no input ports, checking if running");
+            return node_data.running == Some(true);
         };
 
         if node_input_ports.is_empty() {
-            trace!(target: "PWGraph::does_sink_has_active_nodes", "Node ({id}) has no input ports, assuming it is a client");
-            return true;
+            trace!(target: "PWGraph::does_sink_has_active_nodes", "Node ({id}) has no input ports, checking if running");
+            return node_data.running == Some(true);
         };
 
         trace!(
@@ -451,17 +456,8 @@ impl PWGraph {
                 };
                 let LinkData {
                     output_port,
-                    active,
                     ..
                 } = data;
-
-                if let Some(active) = active {
-                    if !active {
-                        continue;
-                    }
-                } else {
-                    continue;
-                }
 
                 let Some(output_port) = output_port else {
                     warn!(target: "PWGraph::does_sink_has_active_nodes", "Link ({link}) is missing output_port");
@@ -473,10 +469,10 @@ impl PWGraph {
         }
 
         if links_to_node.is_empty() {
-            trace!(target: "PWGraph::does_sink_has_active_nodes", "Transversing Graph: Node {id}: No Active Links to node");
+            trace!(target: "PWGraph::does_sink_has_active_nodes", "Transversing Graph: Node {id}: No Links to node");
             return false;
         };
-        trace!(target: "PWGraph::does_sink_has_active_nodes", "Transversing Graph: Node {id}: Active Links to node: {}", links_to_node.len());
+        trace!(target: "PWGraph::does_sink_has_active_nodes", "Transversing Graph: Node {id}: Links to node: {}", links_to_node.len());
 
         for (_, input_port) in links_to_node {
             let Some(PWObject::Port { data, .. }) = self.get(input_port) else {

--- a/src/pipewire_connection/graph/object.rs
+++ b/src/pipewire_connection/graph/object.rs
@@ -47,6 +47,7 @@ pub struct NodeData {
     pub media_class: Option<String>,
     pub media_role: Option<String>,
     pub media_software: Option<String>,
+    pub running: Option<bool>,
 }
 
 impl NodeData {
@@ -103,6 +104,11 @@ impl NodeData {
 
         if new.media_software.is_some() && self.media_software != new.media_software {
             self.media_software = new.media_software;
+            was_updated = true;
+        }
+
+        if new.running.is_some() && self.running != new.running {
+            self.running = new.running;
             was_updated = true;
         }
 

--- a/src/pipewire_connection/mod.rs
+++ b/src/pipewire_connection/mod.rs
@@ -31,7 +31,7 @@ use pipewire::{
     keys,
     link::{Link, LinkChangeMask, LinkInfoRef, LinkListener, LinkState},
     main_loop::MainLoopRc,
-    node::{Node, NodeInfoRef, NodeListener},
+    node::{Node, NodeChangeMask, NodeInfoRef, NodeListener, NodeState},
     port::{Port, PortInfoRef, PortListener},
     registry::{GlobalObject, RegistryRc},
     spa::utils::{Direction, dict::DictRef},
@@ -232,6 +232,7 @@ fn registry_global_node<Msg: From<PWEvent> + Clone + 'static>(
         media_class,
         media_role,
         media_software,
+        running: None,
     };
     graph.borrow_mut().insert(
         id,
@@ -268,6 +269,12 @@ fn node_info<Msg: From<PWEvent> + Clone>(
     let media_role = props.get(&keys::MEDIA_ROLE).map(|s| s.to_string());
     let media_software = props.get(&keys::MEDIA_SOFTWARE).map(|s| s.to_string());
 
+    let running = if info.change_mask().contains(NodeChangeMask::STATE) {
+        Some(matches!(info.state(), NodeState::Running))
+    } else {
+        None
+    };
+
     let new_data = NodeData {
         name,
         app_name,
@@ -276,6 +283,7 @@ fn node_info<Msg: From<PWEvent> + Clone>(
         media_class,
         media_role,
         media_software,
+        running,
     };
     if graph.borrow_mut().update(id, PWObjectData::Node(new_data)) {
         pw_event_listener


### PR DESCRIPTION
Fixes #30.

## Fix

- Track node `Running` state via `NodeInfoRef::state()` in a new `running` field on `NodeData`
- Follow all existing links during DFS traversal regardless of their active state
- At leaf nodes (no input ports), check `running == Some(true)` instead of unconditionally returning true

A playing stream (Running) correctly inhibits idle, while a paused/corked stream (Idle/Suspended) won't — even when the links between them and the sink remain in the graph.

## Testing

Tested on a MacBook Pro M1 Pro (J316) running Fedora Asahi with the `audio_effect.j316-convolver` filter chain. Before the fix, playing audio in Zen browser never triggered the inhibitor. After, it correctly enables/disables based on playback state.