### PR TITLE
Write inhibition state to file

### DIFF
--- a/src/idle_inhibitor/wayland/mod.rs
+++ b/src/idle_inhibitor/wayland/mod.rs
@@ -20,6 +20,7 @@ use std::collections::HashMap;
 use std::error::Error;
 use std::iter::repeat_with;
 use std::os::fd::{AsFd, OwnedFd};
+use std::path::PathBuf;
 
 use nix::errno::Errno;
 use nix::fcntl::OFlag;
@@ -31,8 +32,8 @@ use wayland_client::backend::ObjectId;
 use wayland_client::protocol::wl_buffer;
 use wayland_client::protocol::wl_output::WlOutput;
 use wayland_client::{
-    Connection, Dispatch, EventQueue, Proxy, QueueHandle, delegate_noop,
-    globals::{GlobalListContents, registry_queue_init},
+    delegate_noop,
+    globals::{registry_queue_init, GlobalListContents},
     protocol::{
         wl_buffer::WlBuffer,
         wl_compositor::WlCompositor,
@@ -41,6 +42,7 @@ use wayland_client::{
         wl_shm_pool::WlShmPool,
         wl_surface::WlSurface,
     },
+    Connection, Dispatch, EventQueue, Proxy, QueueHandle,
 };
 
 use wayland_protocols::wp::idle_inhibit::zv1::client::{
@@ -67,6 +69,7 @@ pub struct WaylandIdleInhibitor {
     wlr_layer_shell: ZwlrLayerShellV1,
     idle_inhibit_manager: ZwpIdleInhibitManagerV1,
     outputs: HashMap<u32, Output>, // The u32 key represents a proxy name, the ID used by Wayland
+    state_file: PathBuf,
 
     is_idle_inhibited: bool,
 }
@@ -124,6 +127,22 @@ impl WaylandIdleInhibitor {
             })
             .collect();
 
+        let state_file: PathBuf = std::env::var("XDG_STATE_HOME")
+            .map(PathBuf::from)
+            .ok()
+            .or_else(|| {
+                std::env::home_dir().map(|mut home| {
+                    home.push(".local");
+                    home.push("state");
+                    home
+                })
+            })
+            .unwrap_or_else(|| PathBuf::from("/tmp")) // last resort
+            .join("wayland-pipewire-idle-inhibit");
+
+        // safety: if /tmp doesn't exist that's quite problematic
+        std::fs::create_dir_all(state_file.parent().unwrap())?;
+
         let mut obj = Self {
             compositor,
             qhandle,
@@ -132,6 +151,7 @@ impl WaylandIdleInhibitor {
             idle_inhibit_manager,
             outputs,
             is_idle_inhibited: false,
+            state_file,
         };
         obj.init_missing_surfaces();
 
@@ -213,7 +233,11 @@ impl WaylandIdleInhibitor {
 
         if changed_value {
             //self.roundtrip()?;
-            log::info!(target: "WaylandIdleInhibitor::set_inhibit_idle", "Idle Inhibitor was {}", if inhibit_idle {"ENABLED"} else {"DISABLED"});
+            let str = if inhibit_idle { "ENABLED" } else { "DISABLED" };
+
+            log::info!(target: "WaylandIdleInhibitor::set_inhibit_idle", "Idle Inhibitor was {}", str);
+
+            std::fs::write(&self.state_file, str)?;
         }
 
         Ok(())


### PR DESCRIPTION
Hello :wave: 

Sometimes, it didn't seem like the program was running, and I really wanted to display the state in my status bar. I saw #33 and figured I could take a shot at it. It wasn't after I finished implementing that I saw #21 and #28. However, after reviewing both those PRs, I think mine is still different (and simple) enough to submit, so here it is!

I just wanted a really simple feature to show the idle inhibition status in my status bar. Nothing more, nothing less. Exposing a CLI flag would likely require some sort of IPC implementation -- totally overkill for this feature.

The way it works is very simple: when the idle inhibition state changes, write the state to a file. The two possible states are: `ENABLED`, `DISABLED`. This makes it very easy for scripts to consume this file.

The file location defaults to `$XDG_STATE_HOME/wayland-pipewire-idle-inhibit`. `XDG_STATE_HOME` isn't set, we fall back to `$HOME/.local/state/wayland-pipewire-idle-inhibit`. If `HOME` is unset, we fall back to `/tmp` as a last resort.

<details><summary>Click to show Waybar integration</summary>

This PR doesn't add any specific integration. It just writes to a file. This means that any application can consume this file and do with it what they want. 

For example, here's a really simple script that outputs JSON waybar expects:
```sh
#!/bin/sh

state_file="$XDG_STATE_HOME/wayland-pipewire-idle-inhibit"

state="$(cat "$state_file")" || exit 1
percentage=0

if [ "$state" = 'ENABLED' ]; then
    percentage=100
fi

jq --unbuffered --compact-output --null-input \
    --arg text "$state" \
    --arg alt "$state" \
    --arg tooltip "$state" \
    --arg class '' \
    --arg percentage $percentage \
    '{
        text: $text,
        alt: $alt,
        tooltip: $tooltip,
        class: $class,
        percentage: $percentage
    }'
```

In Waybar's `config`, a custom module can call this script and display the appropriate status:
```json
"custom/idle_inhibit": {
    "format": "{icon}",
    "format-icons": {
        "ENABLED": "󰒲",
        "DISABLED": "󰒳"
    },
    "tooltip-format": "{text}",
    "interval": 1,
    "exec": "~/.config/waybar/scripts/wayland-pipewire-idle-inhibit.sh",
    "return-type": "json"
}
```

</details>

No pressure to merge this. I'm running this from source and not a package, so it's trivial for me to maintain locally. But if you are interested in accepting this and have feedback, let me know!